### PR TITLE
refactor: remove the duplicated initialization code on Llama2Runner

### DIFF
--- a/crabml-cli/src/main.rs
+++ b/crabml-cli/src/main.rs
@@ -65,7 +65,7 @@ fn main() -> Result<()> {
     // let model_wgpu = WgpuLlama2Model::from_cpu(&model_cpu, device_wgpu)?;
 
     let mut sampler = Llama2Sampler::new(conf.vocab_size, args.temperature, args.probability);
-    let mut runner = Llama2Runner::new(&model_cpu, metrics)?;
+    let mut runner = Llama2Runner::new(&model_cpu, metrics.clone())?;
 
     if args.verbose {
         for tensor in gf.tensor_infos() {

--- a/crabml-cli/src/main.rs
+++ b/crabml-cli/src/main.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use crabml::backends::cpu::CpuTensorDevice;
 use crabml::error::Result;
 use crabml::gguf::GGUFFileLoader;
-use crabml::tensor::TensorDeviceMetrics;
+use crabml::tensor::TensorMetrics;
 use crabml_llama2::llama2::Llama2Runner;
 use crabml_llama2::sampler::Llama2Sampler;
 use crabml_llama2::CpuLlama2Model;
@@ -54,7 +54,7 @@ fn main() -> Result<()> {
     let gl = GGUFFileLoader::new(&args.model)?;
     let gf = gl.open()?;
 
-    let metrics = TensorDeviceMetrics::default();
+    let metrics = TensorMetrics::default();
     let device_cpu = CpuTensorDevice::new().with_metrics(metrics.clone());
     let model_cpu = CpuLlama2Model::load(&gf, device_cpu)?;
     let conf = model_cpu.conf.clone();
@@ -65,7 +65,7 @@ fn main() -> Result<()> {
     // let model_wgpu = WgpuLlama2Model::from_cpu(&model_cpu, device_wgpu)?;
 
     let mut sampler = Llama2Sampler::new(conf.vocab_size, args.temperature, args.probability);
-    let mut runner = Llama2Runner::new(&model_cpu)?;
+    let mut runner = Llama2Runner::new(&model_cpu, metrics)?;
 
     if args.verbose {
         for tensor in gf.tensor_infos() {

--- a/crabml-cli/src/main.rs
+++ b/crabml-cli/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<()> {
     let metrics = TensorDeviceMetrics::default();
     let device_cpu = CpuTensorDevice::new().with_metrics(metrics.clone());
     let model_cpu = CpuLlama2Model::load(&gf, device_cpu)?;
-    let conf = model_cpu.conf();
+    let conf = model_cpu.conf.clone();
 
     // let device_wgpu = WgpuTensorDevice::new(
     //     WgpuTensorDeviceOptions::new().with_staging_buf_bytes(conf.vocab_size * 4),
@@ -65,7 +65,7 @@ fn main() -> Result<()> {
     // let model_wgpu = WgpuLlama2Model::from_cpu(&model_cpu, device_wgpu)?;
 
     let mut sampler = Llama2Sampler::new(conf.vocab_size, args.temperature, args.probability);
-    let mut runner = Llama2Runner::try_from(&model_cpu)?;
+    let mut runner = Llama2Runner::new(&model_cpu)?;
 
     if args.verbose {
         for tensor in gf.tensor_infos() {

--- a/crabml-core/src/backends/cpu/cpu_device.rs
+++ b/crabml-core/src/backends/cpu/cpu_device.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use half::f16;
 
 use super::CpuTensor;
-use crate::tensor::TensorDeviceMetrics;
+use crate::tensor::TensorMetrics;
 
 #[derive(Debug, Clone, Default)]
 pub struct CpuTensorDeviceOptions {
@@ -17,7 +17,7 @@ pub struct CpuTensorDeviceOptions {
 #[derive(Debug)]
 pub struct CpuTensorDevice<'a> {
     pub(crate) opts: CpuTensorDeviceOptions,
-    pub(crate) metrics: TensorDeviceMetrics,
+    pub(crate) metrics: TensorMetrics,
     pub(crate) debug_tensors: RefCell<HashMap<String, Vec<f32>>>,
     pub(crate) wbuf: RefCell<Option<Vec<f32>>>,
     pub(crate) exp_cache: Vec<f16>,
@@ -31,7 +31,7 @@ impl<'a> CpuTensorDevice<'a> {
         let device = Self {
             opts: CpuTensorDeviceOptions::default(),
             debug_tensors: RefCell::new(HashMap::new()),
-            metrics: TensorDeviceMetrics::default(),
+            metrics: TensorMetrics::default(),
             wbuf: RefCell::new(Some(vec![0.0; 32000])),
             exp_cache: Self::init_exp_cache(),
             _phantom: std::marker::PhantomData,
@@ -43,7 +43,7 @@ impl<'a> CpuTensorDevice<'a> {
         let device = Self {
             opts,
             debug_tensors: RefCell::new(HashMap::new()),
-            metrics: TensorDeviceMetrics::default(),
+            metrics: TensorMetrics::default(),
             wbuf: RefCell::new(Some(vec![0.0; 32000])),
             exp_cache: Self::init_exp_cache(),
             _phantom: std::marker::PhantomData,
@@ -51,7 +51,7 @@ impl<'a> CpuTensorDevice<'a> {
         Rc::new(device)
     }
 
-    pub fn with_metrics(self: Rc<Self>, metrics: TensorDeviceMetrics) -> CpuTensorDeviceRef<'a> {
+    pub fn with_metrics(self: Rc<Self>, metrics: TensorMetrics) -> CpuTensorDeviceRef<'a> {
         let device = Self {
             opts: self.opts.clone(),
             debug_tensors: self.debug_tensors.clone(),
@@ -63,7 +63,7 @@ impl<'a> CpuTensorDevice<'a> {
         Rc::new(device)
     }
 
-    pub fn metrics(&self) -> &TensorDeviceMetrics {
+    pub fn metrics(&self) -> &TensorMetrics {
         &self.metrics
     }
 

--- a/crabml-core/src/backends/cpu/cpu_tensor.rs
+++ b/crabml-core/src/backends/cpu/cpu_tensor.rs
@@ -118,6 +118,7 @@ impl<'a> Tensor for CpuTensor<'a> {
     type Device = CpuTensorDeviceRef<'a>;
 
     fn alloc(shape: &[usize], _capacity: Option<usize>, device: Self::Device) -> Result<Self> {
+        let _t = device.metrics.alloc_walltime.track();
         let buf = vec![0.0; shape.iter().product()];
         Self::new(buf, shape, device)
     }

--- a/crabml-core/src/backends/cpu/cpu_tensor.rs
+++ b/crabml-core/src/backends/cpu/cpu_tensor.rs
@@ -215,6 +215,7 @@ impl<'a> Tensor for CpuTensor<'a> {
 
     // TODO(2024-02-15): dequantize the tensor here, not dequantize the embedding table on loading
     fn copy_from(&mut self, src: &CpuTensor<'a>, pos: &[usize], len: usize) -> Result<()> {
+        let _t = self.device.metrics.copy_walltime.track();
         if !self.is_owned() {
             return Err((ErrorKind::TensorError, "not owned").into());
         }

--- a/crabml-core/src/gguf.rs
+++ b/crabml-core/src/gguf.rs
@@ -809,6 +809,12 @@ impl GGUFFileLoader {
                 cause: Some(Box::new(err)),
             })?
         };
+        mmap.advise(memmap2::Advice::Sequential)
+            .map_err(|err| Error {
+                kind: ErrorKind::IOError,
+                message: format!("failed to advise the mmap: {}", path),
+                cause: Some(Box::new(err)),
+            })?; // hint the kernel that we will read the file sequentially
 
         Ok(Self { mmap })
     }

--- a/crabml-core/src/gguf.rs
+++ b/crabml-core/src/gguf.rs
@@ -809,13 +809,6 @@ impl GGUFFileLoader {
                 cause: Some(Box::new(err)),
             })?
         };
-        mmap.advise(memmap2::Advice::Sequential)
-            .map_err(|err| Error {
-                kind: ErrorKind::IOError,
-                message: format!("failed to advise the mmap: {}", path),
-                cause: Some(Box::new(err)),
-            })?; // hint the kernel that we will read the file sequentially
-
         Ok(Self { mmap })
     }
 

--- a/crabml-core/src/tensor/metrics.rs
+++ b/crabml-core/src/tensor/metrics.rs
@@ -15,6 +15,8 @@ pub struct TensorDeviceMetrics {
     pub matmul_quantize_walltime: TimeMetric,
     pub matmul_vec_dot_walltime: TimeMetric,
     pub batch_matmul_walltime: TimeMetric,
+    pub alloc_walltime: TimeMetric,
+    pub sample_walltime: TimeMetric,
 }
 
 impl TensorDeviceMetrics {
@@ -30,6 +32,8 @@ impl TensorDeviceMetrics {
         self.matmul_quantize_walltime.reset();
         self.matmul_vec_dot_walltime.reset();
         self.batch_matmul_walltime.reset();
+        self.alloc_walltime.reset();
+        self.sample_walltime.reset();
     }
 
     pub fn as_vec(&self) -> Vec<(String, f64)> {
@@ -38,10 +42,18 @@ impl TensorDeviceMetrics {
                 "rms_norm_walltime".to_string(),
                 self.rms_norm_walltime.as_millis(),
             ),
+            (
+                "sample_walltime".to_string(),
+                self.sample_walltime.as_millis(),
+            ),
             ("add_walltime".to_string(), self.add_walltime.as_millis()),
             (
                 "activate_walltime".to_string(),
                 self.activate_walltime.as_millis(),
+            ),
+            (
+                "alloc_walltime".to_string(),
+                self.alloc_walltime.as_millis(),
             ),
             (
                 "total_walltime".to_string(),

--- a/crabml-core/src/tensor/metrics.rs
+++ b/crabml-core/src/tensor/metrics.rs
@@ -18,6 +18,10 @@ pub struct TensorMetrics {
     pub alloc_walltime: TimeMetric,
     pub sample_walltime: TimeMetric,
     pub forward_walltime: TimeMetric,
+    pub save_kvcache_walltime: TimeMetric,
+    pub mqa_walltime: TimeMetric,
+    pub ffn_walltime: TimeMetric,
+    pub copy_walltime: TimeMetric,
 }
 
 impl TensorMetrics {
@@ -36,6 +40,10 @@ impl TensorMetrics {
         self.alloc_walltime.reset();
         self.sample_walltime.reset();
         self.forward_walltime.reset();
+        self.save_kvcache_walltime.reset();
+        self.mqa_walltime.reset();
+        self.ffn_walltime.reset();
+        self.copy_walltime.reset();
     }
 
     pub fn as_vec(&self) -> Vec<(String, f64)> {
@@ -87,6 +95,13 @@ impl TensorMetrics {
                 "batch_matmul_walltime".to_string(),
                 self.batch_matmul_walltime.as_millis(),
             ),
+            (
+                "save_kv_cache_walltime".to_string(),
+                self.save_kvcache_walltime.as_millis(),
+            ),
+            ("mqa_walltime".to_string(), self.mqa_walltime.as_millis()),
+            ("ffn_walltime".to_string(), self.ffn_walltime.as_millis()),
+            ("copy_walltime".to_string(), self.copy_walltime.as_millis()),
         ]
     }
 }

--- a/crabml-core/src/tensor/metrics.rs
+++ b/crabml-core/src/tensor/metrics.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 /// stores the metrics on the tensor's privimives
 #[derive(Debug, Default, Clone)]
-pub struct TensorDeviceMetrics {
+pub struct TensorMetrics {
     pub rms_norm_walltime: TimeMetric,
     pub add_walltime: TimeMetric,
     pub total_walltime: TimeMetric,
@@ -19,7 +19,7 @@ pub struct TensorDeviceMetrics {
     pub sample_walltime: TimeMetric,
 }
 
-impl TensorDeviceMetrics {
+impl TensorMetrics {
     pub fn reset(&self) {
         self.rms_norm_walltime.reset();
         self.add_walltime.reset();

--- a/crabml-core/src/tensor/metrics.rs
+++ b/crabml-core/src/tensor/metrics.rs
@@ -17,6 +17,7 @@ pub struct TensorMetrics {
     pub batch_matmul_walltime: TimeMetric,
     pub alloc_walltime: TimeMetric,
     pub sample_walltime: TimeMetric,
+    pub forward_walltime: TimeMetric,
 }
 
 impl TensorMetrics {
@@ -34,6 +35,7 @@ impl TensorMetrics {
         self.batch_matmul_walltime.reset();
         self.alloc_walltime.reset();
         self.sample_walltime.reset();
+        self.forward_walltime.reset();
     }
 
     pub fn as_vec(&self) -> Vec<(String, f64)> {
@@ -41,6 +43,10 @@ impl TensorMetrics {
             (
                 "rms_norm_walltime".to_string(),
                 self.rms_norm_walltime.as_millis(),
+            ),
+            (
+                "forward_walltime".to_string(),
+                self.forward_walltime.as_millis(),
             ),
             (
                 "sample_walltime".to_string(),

--- a/crabml-core/src/tensor/mod.rs
+++ b/crabml-core/src/tensor/mod.rs
@@ -4,5 +4,5 @@ mod strider;
 
 pub use api::RopeMode;
 pub use api::Tensor;
-pub use metrics::TensorDeviceMetrics;
+pub use metrics::TensorMetrics;
 pub use strider::TensorStrider;

--- a/crabml-llama2/src/lib.rs
+++ b/crabml-llama2/src/lib.rs
@@ -3,3 +3,6 @@ pub mod model;
 pub mod sampler;
 
 pub use model::CpuLlama2Model;
+pub use model::Llama2Model;
+pub use model::WgpuLlama2Model;
+pub use sampler::Llama2Sampler;

--- a/crabml-llama2/src/llama2.rs
+++ b/crabml-llama2/src/llama2.rs
@@ -4,8 +4,6 @@ use std::time::Duration;
 use std::time::Instant;
 use std::vec;
 
-use crabml::backends::cpu::CpuTensor;
-use crabml::backends::wgpu::WgpuTensor;
 use crabml::error::Error;
 use crabml::error::ErrorKind;
 use crabml::error::Result;
@@ -13,12 +11,10 @@ use crabml::tensor::RopeMode;
 use crabml::tensor::Tensor;
 use crabml::tokenizer::BpeTokenizer;
 
-use crate::model::CpuLlama2Model;
 use crate::model::Llama2Config;
 use crate::model::Llama2Model;
 use crate::model::Llama2Weights;
 use crate::model::ModelArchitecture;
-use crate::model::WgpuLlama2Model;
 use crate::sampler::Llama2Sampler;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -470,6 +466,8 @@ mod tests {
     use crabml::gguf::GGUFFileLoader;
 
     use super::*;
+    use crate::CpuLlama2Model;
+    use crate::WgpuLlama2Model;
 
     #[test]
     fn test_generate_f32() -> Result<()> {

--- a/crabml-llama2/src/llama2.rs
+++ b/crabml-llama2/src/llama2.rs
@@ -92,6 +92,8 @@ impl<'a, T: Tensor> Llama2Runner<T> {
     }
 
     pub fn forward(&mut self, token: usize, pos: usize) -> Result<&mut [f32]> {
+        let _t = self.metrics.forward_walltime.track();
+
         let x = match self.conf.architecture {
             ModelArchitecture::Llama => self.forward_llama(token, pos)?,
             ModelArchitecture::Gemma => self.forward_gemma(token, pos)?,

--- a/crabml-llama2/src/llama2.rs
+++ b/crabml-llama2/src/llama2.rs
@@ -273,8 +273,10 @@ impl<'a, T: Tensor> Llama2Runner<T> {
         embed_dim: usize,
         head_dim: usize,
     ) -> Result<T> {
+        let _t = self.metrics.mqa_walltime.track();
         // save to kv cache
         {
+            let _t = self.metrics.save_kvcache_walltime.track();
             let v = v
                 .reshape(&[n_kv_heads, head_dim])?
                 .repeat_n(n_heads / n_kv_heads)?;
@@ -329,6 +331,7 @@ impl<'a, T: Tensor> Llama2Runner<T> {
     }
 
     fn forward_ffn(&self, mut x: T, l: usize, activation: Activation) -> Result<T> {
+        let _t = self.metrics.ffn_walltime.track();
         // save for redidual connection
         let x_orig_ffn = x.dup()?;
 

--- a/crabml-llama2/src/llama2.rs
+++ b/crabml-llama2/src/llama2.rs
@@ -81,7 +81,14 @@ impl<'a, T: Tensor> Llama2Runner<T> {
         steps: usize,
         sampler: &'a mut Llama2Sampler,
     ) -> Result<Llama2RunnerOutputGenerator<'a, T>> {
-        Llama2RunnerOutputGenerator::new(self, sampler, prompt, steps, self.conf.seq_len)
+        Llama2RunnerOutputGenerator::new(
+            self,
+            sampler,
+            self.metrics.clone(),
+            prompt,
+            steps,
+            self.conf.seq_len,
+        )
     }
 
     pub fn forward(&mut self, token: usize, pos: usize) -> Result<&mut [f32]> {
@@ -363,6 +370,7 @@ pub struct Llama2RunnerOutputGenerator<'a, T: Tensor> {
     token: usize,
     sampler: &'a mut Llama2Sampler,
     runner: &'a mut Llama2Runner<T>,
+    _metrics: TensorMetrics,
     total_time: Duration,
 }
 
@@ -370,6 +378,7 @@ impl<'a, T: Tensor> Llama2RunnerOutputGenerator<'a, T> {
     fn new(
         runner: &'a mut Llama2Runner<T>,
         sampler: &'a mut Llama2Sampler,
+        metrics: TensorMetrics,
         prompt: &str,
         steps: usize,
         seq_len: usize,
@@ -392,6 +401,7 @@ impl<'a, T: Tensor> Llama2RunnerOutputGenerator<'a, T> {
             sampler,
             runner,
             seq_len,
+            _metrics: metrics,
             total_time: Duration::new(0, 0),
         })
     }

--- a/crabml-llama2/src/model.rs
+++ b/crabml-llama2/src/model.rs
@@ -65,11 +65,43 @@ pub struct Llama2Weights<T: Tensor> {
     pub output_weight: Option<T>, // (vocab_size, dim)
 }
 
+pub trait Llama2Model {
+    type T: Tensor;
+
+    fn conf(&self) -> Llama2Config;
+
+    fn device(&self) -> <Self::T as Tensor>::Device;
+
+    fn weights(&self) -> Rc<Llama2Weights<Self::T>>;
+
+    fn tokenizer(&self) -> Rc<BpeTokenizer>;
+}
+
 pub struct CpuLlama2Model<'a> {
     pub conf: Llama2Config,
     pub weights: Rc<Llama2Weights<CpuTensor<'a>>>,
     pub tokenizer: Rc<BpeTokenizer>,
     pub device: CpuTensorDeviceRef<'a>,
+}
+
+impl<'a> Llama2Model for &CpuLlama2Model<'a> {
+    type T = CpuTensor<'a>;
+
+    fn conf(&self) -> Llama2Config {
+        self.conf.clone()
+    }
+
+    fn device(&self) -> CpuTensorDeviceRef<'a> {
+        self.device.clone()
+    }
+
+    fn weights(&self) -> Rc<Llama2Weights<CpuTensor<'a>>> {
+        self.weights.clone()
+    }
+
+    fn tokenizer(&self) -> Rc<BpeTokenizer> {
+        self.tokenizer.clone()
+    }
 }
 
 impl<'a> CpuLlama2Model<'a> {
@@ -83,18 +115,6 @@ impl<'a> CpuLlama2Model<'a> {
             device,
             tokenizer: Rc::new(tokenizer),
         })
-    }
-
-    pub fn conf(&self) -> &Llama2Config {
-        &self.conf
-    }
-
-    pub fn weights(&self) -> Rc<Llama2Weights<CpuTensor<'a>>> {
-        self.weights.clone()
-    }
-
-    pub fn tokenizer(&self) -> Rc<BpeTokenizer> {
-        self.tokenizer.clone()
     }
 
     fn load_weights(
@@ -318,6 +338,26 @@ pub struct WgpuLlama2Model {
     pub weights: Rc<Llama2Weights<WgpuTensor>>,
     pub tokenizer: Rc<BpeTokenizer>,
     pub device: WgpuTensorDeviceRef,
+}
+
+impl Llama2Model for &WgpuLlama2Model {
+    type T = WgpuTensor;
+
+    fn conf(&self) -> Llama2Config {
+        self.conf.clone()
+    }
+
+    fn weights(&self) -> Rc<Llama2Weights<WgpuTensor>> {
+        self.weights.clone()
+    }
+
+    fn device(&self) -> WgpuTensorDeviceRef {
+        self.device.clone()
+    }
+
+    fn tokenizer(&self) -> Rc<BpeTokenizer> {
+        self.tokenizer.clone()
+    }
 }
 
 impl WgpuLlama2Model {


### PR DESCRIPTION
this PR adds a new trait called `Llama2Model` which unify the common parameters from CPU and WGPU, which allows us remove the duplication on initializing Llama2Runner with generics.