### PR TITLE
optimize: sampling and printing

### DIFF
--- a/crabml-cli/Cargo.toml
+++ b/crabml-cli/Cargo.toml
@@ -12,6 +12,7 @@ num_cpus = "1.16.0"
 clap = { version = "4.0", features = ["derive"] }
 crabml-llama2 = { workspace = true }
 crabml = { workspace = true }
+jemallocator = "0.3"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/crabml-cli/src/main.rs
+++ b/crabml-cli/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
 
     let metrics = TensorMetrics::default();
     let device_cpu = CpuTensorDevice::new().with_metrics(metrics.clone());
-    let model_cpu = CpuLlama2Model::load(&gf, device_cpu)?;
+    let model_cpu = CpuLlama2Model::load(&gf, device_cpu.clone())?;
     let conf = model_cpu.conf.clone();
 
     // let device_wgpu = WgpuTensorDevice::new(
@@ -64,7 +64,12 @@ fn main() -> Result<()> {
     // );
     // let model_wgpu = WgpuLlama2Model::from_cpu(&model_cpu, device_wgpu)?;
 
-    let mut sampler = Llama2Sampler::new(conf.vocab_size, args.temperature, args.probability);
+    let mut sampler = Llama2Sampler::new(
+        conf.vocab_size,
+        args.temperature,
+        args.probability,
+        device_cpu.exp_cache(),
+    );
     let mut runner = Llama2Runner::new(&model_cpu, metrics.clone())?;
 
     if args.verbose {

--- a/crabml-cli/src/main.rs
+++ b/crabml-cli/src/main.rs
@@ -1,3 +1,5 @@
+extern crate jemallocator;
+
 use std::io::Write;
 use std::time::Instant;
 
@@ -9,6 +11,9 @@ use crabml::tensor::TensorMetrics;
 use crabml_llama2::llama2::Llama2Runner;
 use crabml_llama2::sampler::Llama2Sampler;
 use crabml_llama2::CpuLlama2Model;
+
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 #[derive(Parser, Debug)]
 struct CommandArgs {

--- a/crabml-core/src/backends/cpu/cpu_device.rs
+++ b/crabml-core/src/backends/cpu/cpu_device.rs
@@ -20,7 +20,7 @@ pub struct CpuTensorDevice<'a> {
     pub(crate) metrics: TensorMetrics,
     pub(crate) debug_tensors: RefCell<HashMap<String, Vec<f32>>>,
     pub(crate) wbuf: RefCell<Option<Vec<f32>>>,
-    pub(crate) exp_cache: Vec<f16>,
+    pub(crate) exp_cache: Rc<Vec<f16>>,
     _phantom: std::marker::PhantomData<&'a ()>,
 }
 
@@ -33,7 +33,7 @@ impl<'a> CpuTensorDevice<'a> {
             debug_tensors: RefCell::new(HashMap::new()),
             metrics: TensorMetrics::default(),
             wbuf: RefCell::new(Some(vec![0.0; 32000])),
-            exp_cache: Self::init_exp_cache(),
+            exp_cache: Rc::new(Self::init_exp_cache()),
             _phantom: std::marker::PhantomData,
         };
         Rc::new(device)
@@ -45,7 +45,7 @@ impl<'a> CpuTensorDevice<'a> {
             debug_tensors: RefCell::new(HashMap::new()),
             metrics: TensorMetrics::default(),
             wbuf: RefCell::new(Some(vec![0.0; 32000])),
-            exp_cache: Self::init_exp_cache(),
+            exp_cache: Rc::new(Self::init_exp_cache()),
             _phantom: std::marker::PhantomData,
         };
         Rc::new(device)
@@ -69,6 +69,10 @@ impl<'a> CpuTensorDevice<'a> {
 
     pub fn dump_debug_tensor(&self, name: &str) -> Option<Vec<f32>> {
         self.debug_tensors.borrow().get(name).cloned()
+    }
+
+    pub fn exp_cache(&self) -> Rc<Vec<f16>> {
+        self.exp_cache.clone()
     }
 
     fn init_exp_cache() -> Vec<f16> {

--- a/crabml-core/src/gguf.rs
+++ b/crabml-core/src/gguf.rs
@@ -809,6 +809,12 @@ impl GGUFFileLoader {
                 cause: Some(Box::new(err)),
             })?
         };
+        mmap.advise(memmap2::Advice::WillNeed)
+            .map_err(|err| Error {
+                kind: ErrorKind::IOError,
+                message: format!("failed to advise the mmap: {}", path),
+                cause: Some(Box::new(err)),
+            })?;
         Ok(Self { mmap })
     }
 

--- a/crabml-llama2/Cargo.toml
+++ b/crabml-llama2/Cargo.toml
@@ -12,6 +12,7 @@ rand = "0.8.5"
 rayon = "1.7.0"
 num_cpus = "1.16.0"
 crabml = { workspace = true }
+half = { version = "2.3.1" }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/crabml-llama2/src/llama2.rs
+++ b/crabml-llama2/src/llama2.rs
@@ -375,7 +375,7 @@ pub struct Llama2RunnerOutputGenerator<'a, T: Tensor> {
     token: usize,
     sampler: &'a mut Llama2Sampler,
     runner: &'a mut Llama2Runner<T>,
-    _metrics: TensorMetrics,
+    metrics: TensorMetrics,
     total_time: Duration,
 }
 
@@ -406,7 +406,7 @@ impl<'a, T: Tensor> Llama2RunnerOutputGenerator<'a, T> {
             sampler,
             runner,
             seq_len,
-            _metrics: metrics,
+            metrics,
             total_time: Duration::new(0, 0),
         })
     }
@@ -433,6 +433,7 @@ impl<'a, T: Tensor> Llama2RunnerOutputGenerator<'a, T> {
             // if we are still processing the input prompt, force the next prompt token
             (self.prompt_tokens[self.pos + 1], true)
         } else {
+            let _t = self.metrics.sample_walltime.track();
             // otherwise sample the next token from the logits
             let token = self.sampler.sample(logits)?;
             (token, false)
@@ -498,7 +499,7 @@ mod tests {
         });
         let lm = CpuLlama2Model::load(&gf, device.clone())?;
 
-        let mut sampler = Llama2Sampler::new(lm.conf.vocab_size, 0.0, 0.0);
+        let mut sampler = Llama2Sampler::new(lm.conf.vocab_size, 0.0, 0.0, device.exp_cache());
         let mut runner = Llama2Runner::new(&lm, TensorMetrics::default())?;
         let output = runner.generate("Lily is a cat", 30, &mut sampler)?;
         let s = output.collect::<Result<Vec<String>>>()?.join("");
@@ -516,11 +517,11 @@ mod tests {
         let gf = gl.open()?;
 
         let device = CpuTensorDevice::new();
-        let lm = CpuLlama2Model::load(&gf, device)?;
+        let lm = CpuLlama2Model::load(&gf, device.clone())?;
         assert_eq!(lm.conf.rope_dim, Some(48));
         assert_eq!(lm.conf.head_size(), 48);
 
-        let mut sampler = Llama2Sampler::new(lm.conf.vocab_size, 0.0, 0.0);
+        let mut sampler = Llama2Sampler::new(lm.conf.vocab_size, 0.0, 0.0, device.exp_cache());
         let mut runner = Llama2Runner::new(&lm, TensorMetrics::default())?;
         let output = runner.generate("Lily is a cute cat, ", 10, &mut sampler)?;
         let s = output.collect::<Result<Vec<String>>>()?.join("");
@@ -546,7 +547,8 @@ mod tests {
         );
         let model_wgpu = WgpuLlama2Model::from_cpu(&model_cpu, device_wgpu.clone())?;
 
-        let mut sampler = Llama2Sampler::new(model_cpu.conf.vocab_size, 0.0, 0.0);
+        let mut sampler =
+            Llama2Sampler::new(model_cpu.conf.vocab_size, 0.0, 0.0, device_cpu.exp_cache());
         let mut runner_cpu = Llama2Runner::new(&model_cpu, TensorMetrics::default())?;
         let mut runner_wgpu = Llama2Runner::new(&model_wgpu, TensorMetrics::default())?;
 


### PR DESCRIPTION
this pr made the following optimizations:

- utilize the exp_cache in the sampling phase which makes softmax faster
- use jemalloc as the global allocator, as it said that have a better cache affinity (not actually made a observable performance improvement through)
- addes a print thread to avoid block the token generate computations by printing
- buffer the flush every token (it seems that this change improves most)