### PR TITLE
chore(cli): set cpu as the default device

### DIFF
--- a/crabml-cli/src/main.rs
+++ b/crabml-cli/src/main.rs
@@ -56,8 +56,8 @@ enum DeviceType {
     Wgpu,
 }
 
-impl Display for DeviceType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl std::fmt::Display for DeviceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             DeviceType::Cpu => write!(f, "cpu"),
             DeviceType::Wgpu => write!(f, "wgpu"),

--- a/crabml-cli/src/main.rs
+++ b/crabml-cli/src/main.rs
@@ -46,14 +46,23 @@ struct CommandArgs {
     /// The prompt
     prompt: String,
 
-    #[arg(value_enum)]
-    device_type: DeviceType,
+    #[arg(short = 'D', long, default_value_t = DeviceType::Cpu)]
+    device: DeviceType,
 }
 
 #[derive(Clone, Debug, ValueEnum)]
 enum DeviceType {
     Cpu,
     Wgpu,
+}
+
+impl ToString for DeviceType {
+    fn to_string(&self) -> String {
+        match self {
+            DeviceType::Cpu => "cpu".to_string(),
+            DeviceType::Wgpu => "wgpu".to_string(),
+        }
+    }
 }
 
 fn run<U: Tensor>(
@@ -152,7 +161,7 @@ fn main() -> Result<()> {
         println!("loaded model: {}ms", start_time.elapsed().as_millis());
     }
 
-    match args.device_type {
+    match args.device {
         DeviceType::Cpu => {
             let mut runner = Llama2Runner::new(&model_cpu, metrics.clone(), true)?;
             run(&args, &mut runner, &mut sampler, &metrics)?;

--- a/crabml-cli/src/main.rs
+++ b/crabml-cli/src/main.rs
@@ -56,11 +56,11 @@ enum DeviceType {
     Wgpu,
 }
 
-impl ToString for DeviceType {
-    fn to_string(&self) -> String {
+impl Display for DeviceType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            DeviceType::Cpu => "cpu".to_string(),
-            DeviceType::Wgpu => "wgpu".to_string(),
+            DeviceType::Cpu => write!(f, "cpu"),
+            DeviceType::Wgpu => write!(f, "wgpu"),
         }
     }
 }


### PR DESCRIPTION
currently we'll got an argument error if not specify `cpu` explictly.

this PR set the cpu as the default device, while allows us specify different devices via `-D` argument.

