### PR TITLE
optimize: use a fma on column major gemv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ members = [
     "crabml-cli",
 ]
 
+[profile.release]
+opt-level = 3
+
 [workspace.package]
 version = "0.1.0"
 license = "Apache-2.0"

--- a/crabml-cli/src/main.rs
+++ b/crabml-cli/src/main.rs
@@ -172,7 +172,7 @@ fn main() -> Result<()> {
             );
             let model_wgpu = WgpuLlama2Model::from_cpu(&model_cpu, device_wgpu)?;
 
-            let mut runner = Llama2Runner::new(&model_wgpu, metrics.clone(), true)?;
+            let mut runner = Llama2Runner::new(&model_wgpu, metrics.clone(), false)?;
             run(&args, &mut runner, &mut sampler, &metrics)?;
         }
     }

--- a/crabml-cli/src/main.rs
+++ b/crabml-cli/src/main.rs
@@ -71,29 +71,17 @@ fn run<U: Tensor>(
     sampler: &mut Llama2Sampler,
     metrics: &TensorMetrics,
 ) -> Result<()> {
-    // it seems printing to stdout is not that fast, so we use a separate thread to keep the generation not blocked by the printing
-    let (tx, rx) = std::sync::mpsc::sync_channel(32);
-    let print_thread = std::thread::spawn(move || {
-        let mut step = 0;
-        while let Ok(Some(token)) = rx.recv() {
-            print!("{}", token);
-            step += 1;
-            if step % 2 == 0 {
-                std::io::stdout().flush().unwrap();
-            }
-        }
-        std::io::stdout().flush().unwrap();
-    });
-
     let mut output = runner.generate(&args.prompt, args.steps, sampler)?;
     print!("{}", &args.prompt);
 
     loop {
         let _t = metrics.total_walltime.track();
         match output.next() {
-            Some(token) => tx.send(Some(token?)).unwrap(),
+            Some(token) => {
+                print!("{}", token?);
+                std::io::stdout().flush().unwrap();
+            }
             None => {
-                tx.send(None).unwrap();
                 break;
             }
         }
@@ -109,7 +97,6 @@ fn run<U: Tensor>(
         metrics.reset();
     }
 
-    print_thread.join().unwrap();
     println!();
     println!(
         "{} tokens/s, {} threads",
@@ -158,12 +145,12 @@ fn main() -> Result<()> {
                 tensor.dimensions()
             );
         }
-        println!("loaded model: {}ms", start_time.elapsed().as_millis());
     }
 
     match args.device {
         DeviceType::Cpu => {
-            let mut runner = Llama2Runner::new(&model_cpu, metrics.clone(), true)?;
+            let mut runner = Llama2Runner::new(&model_cpu, metrics.clone(), conf.seq_len, true)?;
+            println!("loaded model: {}ms", start_time.elapsed().as_millis());
             run(&args, &mut runner, &mut sampler, &metrics)?;
         }
         DeviceType::Wgpu => {
@@ -172,7 +159,7 @@ fn main() -> Result<()> {
             );
             let model_wgpu = WgpuLlama2Model::from_cpu(&model_cpu, device_wgpu)?;
 
-            let mut runner = Llama2Runner::new(&model_wgpu, metrics.clone(), false)?;
+            let mut runner = Llama2Runner::new(&model_wgpu, metrics.clone(), conf.seq_len, false)?;
             run(&args, &mut runner, &mut sampler, &metrics)?;
         }
     }

--- a/crabml-core/src/backends/cpu/arch/aarch64.rs
+++ b/crabml-core/src/backends/cpu/arch/aarch64.rs
@@ -92,6 +92,11 @@ pub unsafe fn vld1q_f16(ptr: *const f16) -> float16x8_t {
     core::arch::aarch64::vld1q_u16(ptr as *const u16) as float16x8_t
 }
 
+#[inline]
+pub unsafe fn vst1q_f16(ptr: *mut f16, a: float16x8_t) {
+    core::arch::aarch64::vst1q_u16(ptr as *mut u16, a as uint16x8_t);
+}
+
 /// Broadcast value into [`float16x8_t`]
 /// Fused multiply add [doc](https://developer.arm.com/documentation/dui0801/g/A64-SIMD-Vector-Instructions/FMLA--vector-)
 #[inline]

--- a/crabml-core/src/backends/cpu/buf/buf_f16.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_f16.rs
@@ -195,3 +195,22 @@ pub fn vec_dot_f16_f16_strided_fallback(
     }
     sum.to_f32()
 }
+
+#[cfg(test)]
+mod tests {
+    use half::f16;
+
+    use crate::backends::cpu::buf::buf_f16::vec_fma_f16_f16;
+
+    #[test]
+    fn test_vec_fma_f16_f16() {
+        let a = vec![f16::from_f32(1.0); 16];
+        let mut c = vec![f16::from_f32(0.0); 16];
+        let b = f16::from_f32(2.0);
+        vec_fma_f16_f16(&a, b, &mut c, 0, 16);
+        assert_eq!(c, vec![f16::from_f32(2.0); 16]);
+
+        vec_fma_f16_f16(&a, b, &mut c, 0, 16);
+        assert_eq!(c, vec![f16::from_f32(4.0); 16]);
+    }
+}

--- a/crabml-core/src/backends/cpu/buf/buf_f16.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_f16.rs
@@ -137,6 +137,7 @@ fn vec_fma_f16_f16_neon(a: &[f16], b: f16, c: &mut [f16], a_offset: usize, m: us
     }
 }
 
+#[allow(dead_code)]
 fn vec_fma_f16_f16_fallback(a: &[f16], b: f16, c: &mut [f16], a_offset: usize, m: usize) {
     let m_rounded = m - m % 4;
     for mi in (0..m_rounded).step_by(4) {

--- a/crabml-core/src/backends/cpu/primitives/batch_matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/batch_matmul_vec.rs
@@ -46,7 +46,7 @@ pub fn batch_matmul_vec<'a>(
         CpuTensorBuf::F16(bufa) => {
             let bufb = b.as_f32_ref();
             let bufb = quantize_f32_f16(bufb);
-            let mut tmpc = vec![f16::ZERO; b_batch * m];
+            let mut tmpc = vec![f16::ZERO; b_batch * m]; // TODO: avoid allocation
             batch_matmul_vec_f16(
                 device, bufa, &bufb, &mut tmpc, a_batch, b_batch, m, k, bi_stride, mi_stride,
                 ki_stride,

--- a/crabml-core/src/backends/cpu/primitives/batch_matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/batch_matmul_vec.rs
@@ -3,10 +3,9 @@ use rayon::prelude::*;
 
 use crate::backends::cpu::buf::buf_f16::quantize_f32_f16;
 use crate::backends::cpu::buf::buf_f16::vec_dot_f16_f16;
-use crate::backends::cpu::buf::buf_f16::vec_dot_f16_f16_strided;
+use crate::backends::cpu::buf::buf_f16::vec_fma_f16_f16;
 use crate::backends::cpu::buf::buf_f32::vec_dot_f32_f32_strided;
 use crate::backends::cpu::buf::CpuTensorBuf;
-use crate::backends::cpu::CpuTensorDevice;
 use crate::backends::cpu::CpuTensorDeviceRef;
 use crate::error::ErrorKind;
 use crate::error::Result;
@@ -28,9 +27,8 @@ pub fn batch_matmul_vec<'a>(
     assert!(strider1.shape()[2] == strider2.shape()[1]);
     assert!(strider2.is_contiguous());
 
-    let bufc = c.as_f32_mut();
-
-    let batch = strider1.shape()[0];
+    let a_batch = strider1.shape()[0];
+    let b_batch = strider2.shape()[0];
     let m = strider1.shape()[1];
     let k = strider1.shape()[2];
     let bi_stride = strider1.strides()[0];
@@ -39,17 +37,26 @@ pub fn batch_matmul_vec<'a>(
 
     match a {
         CpuTensorBuf::F32(bufa) => {
+            let bufc = c.as_f32_mut();
             let bufb = b.as_f32_ref();
             batch_matmul_vec_f32(
-                device, bufa, bufb, bufc, batch, m, k, bi_stride, mi_stride, ki_stride,
+                device, bufa, bufb, bufc, a_batch, b_batch, m, k, bi_stride, mi_stride, ki_stride,
             );
         }
         CpuTensorBuf::F16(bufa) => {
             let bufb = b.as_f32_ref();
             let bufb = quantize_f32_f16(bufb);
+            let mut tmpc = vec![f16::ZERO; b_batch * m];
             batch_matmul_vec_f16(
-                device, bufa, &bufb, bufc, batch, m, k, bi_stride, mi_stride, ki_stride,
+                device, bufa, &bufb, &mut tmpc, a_batch, b_batch, m, k, bi_stride, mi_stride,
+                ki_stride,
             );
+            c.as_f32_mut()
+                .iter_mut()
+                .zip(tmpc.iter())
+                .for_each(|(c, tmp)| {
+                    *c = tmp.to_f32();
+                });
         }
         _ => return Err((ErrorKind::TensorError, "a must be f32 or 16").into()),
     };
@@ -62,7 +69,8 @@ fn batch_matmul_vec_f32(
     abuf: &[f32],     // Batch x M x K
     bbuf: &[f32],     // Batch x K
     cbuf: &mut [f32], // Batch x M
-    seq: usize,
+    a_batch: usize,
+    _b_batch: usize,
     m: usize,
     k: usize,
     bi_stride: usize,
@@ -74,7 +82,7 @@ fn batch_matmul_vec_f32(
         let bi = (i - mi) / m;
         *bufcp = vec_dot_f32_f32_strided(
             abuf,
-            (bi % seq) * bi_stride + mi * mi_stride,
+            (bi % a_batch) * bi_stride + mi * mi_stride,
             ki_stride,
             k,
             &bbuf[bi * k..(bi + 1) * k],
@@ -87,8 +95,9 @@ fn batch_matmul_vec_f16(
     device: &CpuTensorDeviceRef,
     abuf: &[f16],     // Batch x M x K
     bbuf: &[f16],     // Batch x K
-    cbuf: &mut [f32], // Batch x M
-    batch: usize,
+    cbuf: &mut [f16], // Batch x M
+    a_batch: usize,
+    b_batch: usize,
     m: usize,
     k: usize,
     a_stride0: usize,
@@ -100,26 +109,26 @@ fn batch_matmul_vec_f16(
         cbuf.par_iter_mut().enumerate().for_each(|(i, bufcp)| {
             let mi = i % m;
             let bi = (i - mi) / m;
-            *bufcp = vec_dot_f16_f16(
+            *bufcp = f16::from_f32(vec_dot_f16_f16(
                 abuf,
-                (bi % batch) * a_stride0 + mi * a_stride1,
+                (bi % a_batch) * a_stride0 + mi * a_stride1,
                 &bbuf[bi * k..(bi + 1) * k],
                 0,
                 k,
-            );
+            ));
         });
     } else {
         let _t = device.metrics.batch_matmul2_walltime.track();
-        cbuf.par_iter_mut().enumerate().for_each(|(i, bufcp)| {
-            let mi = i % m;
-            let bi = (i - mi) / m;
-            *bufcp = vec_dot_f16_f16_strided(
-                abuf,
-                (bi % batch) * a_stride0 + mi * a_stride1,
-                a_stride2,
-                k,
-                &bbuf[bi * k..(bi + 1) * k],
-            );
-        })
+        for bi in 0..b_batch {
+            for ki in 0..k {
+                vec_fma_f16_f16(
+                    abuf,
+                    bbuf[(bi % a_batch) * k + ki],
+                    &mut cbuf[(bi % a_batch) * m..],
+                    (bi % a_batch) * a_stride0 + ki * a_stride2,
+                    m,
+                );
+            }
+        }
     }
 }

--- a/crabml-core/src/backends/cpu/primitives/batch_matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/batch_matmul_vec.rs
@@ -6,6 +6,7 @@ use crate::backends::cpu::buf::buf_f16::vec_dot_f16_f16;
 use crate::backends::cpu::buf::buf_f16::vec_dot_f16_f16_strided;
 use crate::backends::cpu::buf::buf_f32::vec_dot_f32_f32_strided;
 use crate::backends::cpu::buf::CpuTensorBuf;
+use crate::backends::cpu::CpuTensorDevice;
 use crate::backends::cpu::CpuTensorDeviceRef;
 use crate::error::ErrorKind;
 use crate::error::Result;
@@ -14,7 +15,7 @@ use crate::tensor::TensorStrider;
 // (b, m, k) @ (b, k, ) -> (b, m, )
 // a is allowed to be not contiguous, but not quantized
 pub fn batch_matmul_vec<'a>(
-    _device: &CpuTensorDeviceRef<'a>,
+    device: &CpuTensorDeviceRef<'a>,
     a: &CpuTensorBuf<'a>,
     b: &CpuTensorBuf<'a>,
     c: &mut CpuTensorBuf<'a>,
@@ -29,7 +30,7 @@ pub fn batch_matmul_vec<'a>(
 
     let bufc = c.as_f32_mut();
 
-    let seq = strider1.shape()[0];
+    let batch = strider1.shape()[0];
     let m = strider1.shape()[1];
     let k = strider1.shape()[2];
     let bi_stride = strider1.strides()[0];
@@ -39,13 +40,15 @@ pub fn batch_matmul_vec<'a>(
     match a {
         CpuTensorBuf::F32(bufa) => {
             let bufb = b.as_f32_ref();
-            batch_matmul_vec_f32(bufa, bufb, bufc, seq, m, k, bi_stride, mi_stride, ki_stride);
+            batch_matmul_vec_f32(
+                device, bufa, bufb, bufc, batch, m, k, bi_stride, mi_stride, ki_stride,
+            );
         }
         CpuTensorBuf::F16(bufa) => {
             let bufb = b.as_f32_ref();
             let bufb = quantize_f32_f16(bufb);
             batch_matmul_vec_f16(
-                bufa, &bufb, bufc, seq, m, k, bi_stride, mi_stride, ki_stride,
+                device, bufa, &bufb, bufc, batch, m, k, bi_stride, mi_stride, ki_stride,
             );
         }
         _ => return Err((ErrorKind::TensorError, "a must be f32 or 16").into()),
@@ -55,6 +58,7 @@ pub fn batch_matmul_vec<'a>(
 
 #[allow(clippy::too_many_arguments)]
 fn batch_matmul_vec_f32(
+    _device: &CpuTensorDeviceRef,
     abuf: &[f32],     // Batch x M x K
     bbuf: &[f32],     // Batch x K
     cbuf: &mut [f32], // Batch x M
@@ -80,10 +84,11 @@ fn batch_matmul_vec_f32(
 
 #[allow(clippy::too_many_arguments)]
 fn batch_matmul_vec_f16(
+    device: &CpuTensorDeviceRef,
     abuf: &[f16],     // Batch x M x K
     bbuf: &[f16],     // Batch x K
     cbuf: &mut [f32], // Batch x M
-    seq: usize,
+    batch: usize,
     m: usize,
     k: usize,
     a_stride0: usize,
@@ -91,24 +96,26 @@ fn batch_matmul_vec_f16(
     a_stride2: usize,
 ) {
     if a_stride2 == 1 {
+        let _t = device.metrics.batch_matmul1_walltime.track();
         cbuf.par_iter_mut().enumerate().for_each(|(i, bufcp)| {
             let mi = i % m;
             let bi = (i - mi) / m;
             *bufcp = vec_dot_f16_f16(
                 abuf,
-                (bi % seq) * a_stride0 + mi * a_stride1,
+                (bi % batch) * a_stride0 + mi * a_stride1,
                 &bbuf[bi * k..(bi + 1) * k],
                 0,
                 k,
             );
         });
     } else {
+        let _t = device.metrics.batch_matmul2_walltime.track();
         cbuf.par_iter_mut().enumerate().for_each(|(i, bufcp)| {
             let mi = i % m;
             let bi = (i - mi) / m;
             *bufcp = vec_dot_f16_f16_strided(
                 abuf,
-                (bi % seq) * a_stride0 + mi * a_stride1,
+                (bi % batch) * a_stride0 + mi * a_stride1,
                 a_stride2,
                 k,
                 &bbuf[bi * k..(bi + 1) * k],

--- a/crabml-core/src/backends/cpu/primitives/batch_matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/batch_matmul_vec.rs
@@ -105,7 +105,7 @@ fn batch_matmul_vec_f16(
     a_stride2: usize,
 ) {
     if a_stride2 == 1 {
-        let _t = device.metrics.batch_matmul1_walltime.track();
+        let _t = device.metrics.batch_matmul_rowwise_walltime.track();
         cbuf.par_iter_mut().enumerate().for_each(|(i, bufcp)| {
             let mi = i % m;
             let bi = (i - mi) / m;
@@ -118,7 +118,7 @@ fn batch_matmul_vec_f16(
             ));
         });
     } else {
-        let _t = device.metrics.batch_matmul2_walltime.track();
+        let _t = device.metrics.batch_matmul_colwise_walltime.track();
         for bi in 0..b_batch {
             for ki in 0..k {
                 vec_fma_f16_f16(

--- a/crabml-core/src/backends/cpu/primitives/concatenate.rs
+++ b/crabml-core/src/backends/cpu/primitives/concatenate.rs
@@ -36,7 +36,10 @@ pub fn concatenate_inplace<'a>(
             |x| x,
         )?,
         (CpuTensorBuf::F16(Cow::Owned(buf1)), CpuTensorBuf::F32(buf2)) => {
-            if strider2.shape().len() == 3 {
+            if strider2.shape().len() == 3
+                && strider2.strides()[2] == 1
+                && strider1.strides()[2] == 1
+            {
                 concatenate_3d_f16_f32(
                     buf1,
                     buf2,
@@ -181,21 +184,22 @@ pub fn concatenate_3d_f16_f32(
     let stride2_1 = strides2[1];
     let stride2_2 = strides2[2];
 
+    let mut tmp = [f16::ZERO; 4];
     for x in 0..shape2[0] {
         for y in 0..shape2[1] {
-            for z in (0..shape2[2]).step_by(4) {
+            let z_rounded = shape2[2] - shape2[2] % 8;
+            for z in (0..z_rounded).step_by(8) {
                 let buf1_offset = buf1_offset + x * stride1_0 + y * stride1_1 + z * stride1_2;
                 let buf2_offset = x * stride2_0 + y * stride2_1 + z * stride2_2;
-                unsafe {
-                    *buf1.get_unchecked_mut(buf1_offset) =
-                        f16::from_f32(*buf2.get_unchecked(buf2_offset));
-                    *buf1.get_unchecked_mut(buf1_offset + stride1_2) =
-                        f16::from_f32(*buf2.get_unchecked(buf2_offset + stride2_2));
-                    *buf1.get_unchecked_mut(buf1_offset + stride1_2 * 2) =
-                        f16::from_f32(*buf2.get_unchecked(buf2_offset + stride2_2 * 2));
-                    *buf1.get_unchecked_mut(buf1_offset + stride1_2 * 3) =
-                        f16::from_f32(*buf2.get_unchecked(buf2_offset + stride2_2 * 3));
-                }
+                tmp.iter_mut()
+                    .zip(&buf2[buf2_offset..buf2_offset + 8])
+                    .for_each(|(x, y)| *x = f16::from_f32(*y));
+                buf1[buf1_offset..buf1_offset + 8].copy_from_slice(&tmp);
+            }
+            for z in z_rounded..shape2[2] {
+                let buf1_offset = buf1_offset + x * stride1_0 + y * stride1_1 + z * stride1_2;
+                let buf2_offset = x * stride2_0 + y * stride2_1 + z * stride2_2;
+                buf1[buf1_offset] = f16::from_f32(buf2[buf2_offset]);
             }
         }
     }

--- a/crabml-core/src/backends/cpu/primitives/concatenate.rs
+++ b/crabml-core/src/backends/cpu/primitives/concatenate.rs
@@ -184,19 +184,9 @@ pub fn concatenate_3d_f16_f32(
     let stride2_1 = strides2[1];
     let stride2_2 = strides2[2];
 
-    let mut tmp = [f16::ZERO; 4];
     for x in 0..shape2[0] {
         for y in 0..shape2[1] {
-            let z_rounded = shape2[2] - shape2[2] % 8;
-            for z in (0..z_rounded).step_by(8) {
-                let buf1_offset = buf1_offset + x * stride1_0 + y * stride1_1 + z * stride1_2;
-                let buf2_offset = x * stride2_0 + y * stride2_1 + z * stride2_2;
-                tmp.iter_mut()
-                    .zip(&buf2[buf2_offset..buf2_offset + 8])
-                    .for_each(|(x, y)| *x = f16::from_f32(*y));
-                buf1[buf1_offset..buf1_offset + 8].copy_from_slice(&tmp);
-            }
-            for z in z_rounded..shape2[2] {
+            for z in 0..shape2[2] {
                 let buf1_offset = buf1_offset + x * stride1_0 + y * stride1_1 + z * stride1_2;
                 let buf2_offset = x * stride2_0 + y * stride2_1 + z * stride2_2;
                 buf1[buf1_offset] = f16::from_f32(buf2[buf2_offset]);

--- a/crabml-core/src/tensor/metrics.rs
+++ b/crabml-core/src/tensor/metrics.rs
@@ -26,6 +26,8 @@ pub struct TensorMetrics {
     pub repeat_n_walltime: TimeMetric,
     pub dup_walltime: TimeMetric,
     pub contiguous_walltime: TimeMetric,
+    pub batch_matmul1_walltime: TimeMetric,
+    pub batch_matmul2_walltime: TimeMetric,
 }
 
 impl TensorMetrics {
@@ -52,6 +54,8 @@ impl TensorMetrics {
         self.repeat_n_walltime.reset();
         self.dup_walltime.reset();
         self.contiguous_walltime.reset();
+        self.batch_matmul1_walltime.reset();
+        self.batch_matmul2_walltime.reset();
     }
 
     pub fn as_vec(&self) -> Vec<(String, f64)> {
@@ -128,6 +132,14 @@ impl TensorMetrics {
                 self.repeat_n_walltime.as_millis(),
             ),
             ("dup_walltime".to_string(), self.dup_walltime.as_millis()),
+            (
+                "batch_matmul1_walltime".to_string(),
+                self.batch_matmul1_walltime.as_millis(),
+            ),
+            (
+                "batch_matmul2_walltime".to_string(),
+                self.batch_matmul2_walltime.as_millis(),
+            ),
             (
                 "contiguous_walltime".to_string(),
                 self.contiguous_walltime.as_millis(),

--- a/crabml-core/src/tensor/metrics.rs
+++ b/crabml-core/src/tensor/metrics.rs
@@ -23,7 +23,6 @@ pub struct TensorMetrics {
     pub save_kvcache_walltime: TimeMetric,
     pub copy_from_walltime: TimeMetric,
     pub concatenate_walltime: TimeMetric,
-    pub repeat_n_walltime: TimeMetric,
     pub dup_walltime: TimeMetric,
     pub contiguous_walltime: TimeMetric,
     pub batch_matmul1_walltime: TimeMetric,
@@ -51,7 +50,6 @@ impl TensorMetrics {
         self.save_kvcache_walltime.reset();
         self.copy_from_walltime.reset();
         self.concatenate_walltime.reset();
-        self.repeat_n_walltime.reset();
         self.dup_walltime.reset();
         self.contiguous_walltime.reset();
         self.batch_matmul1_walltime.reset();
@@ -127,19 +125,7 @@ impl TensorMetrics {
                 "concatenate_walltime".to_string(),
                 self.concatenate_walltime.as_millis(),
             ),
-            (
-                "repeat_n_walltime".to_string(),
-                self.repeat_n_walltime.as_millis(),
-            ),
             ("dup_walltime".to_string(), self.dup_walltime.as_millis()),
-            (
-                "batch_matmul1_walltime".to_string(),
-                self.batch_matmul1_walltime.as_millis(),
-            ),
-            (
-                "batch_matmul2_walltime".to_string(),
-                self.batch_matmul2_walltime.as_millis(),
-            ),
             (
                 "contiguous_walltime".to_string(),
                 self.contiguous_walltime.as_millis(),

--- a/crabml-core/src/tensor/metrics.rs
+++ b/crabml-core/src/tensor/metrics.rs
@@ -25,8 +25,8 @@ pub struct TensorMetrics {
     pub concatenate_walltime: TimeMetric,
     pub dup_walltime: TimeMetric,
     pub contiguous_walltime: TimeMetric,
-    pub batch_matmul1_walltime: TimeMetric,
-    pub batch_matmul2_walltime: TimeMetric,
+    pub batch_matmul_rowwise_walltime: TimeMetric,
+    pub batch_matmul_colwise_walltime: TimeMetric,
 }
 
 impl TensorMetrics {
@@ -52,8 +52,8 @@ impl TensorMetrics {
         self.concatenate_walltime.reset();
         self.dup_walltime.reset();
         self.contiguous_walltime.reset();
-        self.batch_matmul1_walltime.reset();
-        self.batch_matmul2_walltime.reset();
+        self.batch_matmul_rowwise_walltime.reset();
+        self.batch_matmul_colwise_walltime.reset();
     }
 
     pub fn as_vec(&self) -> Vec<(String, f64)> {
@@ -120,6 +120,14 @@ impl TensorMetrics {
             (
                 "dequantize_walltime".to_string(),
                 self.dequantize_walltime.as_millis(),
+            ),
+            (
+                "batch_matmul_rowwise_walltime".to_string(),
+                self.batch_matmul_rowwise_walltime.as_millis(),
+            ),
+            (
+                "batch_matmul_colwise_walltime".to_string(),
+                self.batch_matmul_colwise_walltime.as_millis(),
             ),
             (
                 "concatenate_walltime".to_string(),

--- a/crabml-llama2/src/llama2.rs
+++ b/crabml-llama2/src/llama2.rs
@@ -40,6 +40,7 @@ impl<'a, T: Tensor> Llama2Runner<T> {
     pub fn new(
         model: impl Llama2Model<T = T>,
         metrics: TensorMetrics,
+        seq_len: usize,
         use_f16_kv_cache: bool,
     ) -> Result<Self> {
         let kv_cache_dtype = if use_f16_kv_cache {
@@ -53,7 +54,6 @@ impl<'a, T: Tensor> Llama2Runner<T> {
         let weights = model.weights();
         let tokenizer = model.tokenizer();
         let logits = vec![0.0; conf.vocab_size];
-        let seq_len = conf.seq_len;
         let key_cache = (0..conf.n_layers)
             .map(|_| {
                 T::alloc(
@@ -510,7 +510,7 @@ mod tests {
         let lm = CpuLlama2Model::load(&gf, device.clone())?;
 
         let mut sampler = Llama2Sampler::new(lm.conf.vocab_size, 0.0, 0.0, device.exp_cache());
-        let mut runner = Llama2Runner::new(&lm, TensorMetrics::default(), false)?;
+        let mut runner = Llama2Runner::new(&lm, TensorMetrics::default(), 200, false)?;
         let output = runner.generate("Lily is a cat", 30, &mut sampler)?;
         let s = output.collect::<Result<Vec<String>>>()?.join("");
 
@@ -532,7 +532,7 @@ mod tests {
         assert_eq!(lm.conf.head_size(), 48);
 
         let mut sampler = Llama2Sampler::new(lm.conf.vocab_size, 0.0, 0.0, device.exp_cache());
-        let mut runner = Llama2Runner::new(&lm, TensorMetrics::default(), false)?;
+        let mut runner = Llama2Runner::new(&lm, TensorMetrics::default(), 200, false)?;
         let output = runner.generate("Lily is a cute cat, ", 10, &mut sampler)?;
         let s = output.collect::<Result<Vec<String>>>()?.join("");
         assert_eq!(s, "3 years old. She likes to play with her");
@@ -550,7 +550,7 @@ mod tests {
         assert_eq!(lm.conf.head_size(), 48);
 
         let mut sampler = Llama2Sampler::new(lm.conf.vocab_size, 0.0, 0.0, device.exp_cache());
-        let mut runner = Llama2Runner::new(&lm, TensorMetrics::default(), true)?;
+        let mut runner = Llama2Runner::new(&lm, TensorMetrics::default(), 200, true)?;
         let output = runner.generate("Lily is a cute cat, ", 10, &mut sampler)?;
         let s = output.collect::<Result<Vec<String>>>()?.join("");
         assert_eq!(s, "3 years old. She likes to play with her");
@@ -568,7 +568,7 @@ mod tests {
         assert_eq!(lm.conf.head_size(), 4);
 
         let mut sampler = Llama2Sampler::new(lm.conf.vocab_size, 0.0, 0.0, device.exp_cache());
-        let mut runner = Llama2Runner::new(&lm, TensorMetrics::default(), false)?;
+        let mut runner = Llama2Runner::new(&lm, TensorMetrics::default(), 200, false)?;
         let output = runner.generate("Lily is a cute cat, ", 10, &mut sampler)?;
         let s = output.collect::<Result<Vec<String>>>()?.join("");
         assert_eq!(s, "3 year old. She likes to play with her friends");
@@ -595,8 +595,8 @@ mod tests {
 
         let mut sampler =
             Llama2Sampler::new(model_cpu.conf.vocab_size, 0.0, 0.0, device_cpu.exp_cache());
-        let mut runner_cpu = Llama2Runner::new(&model_cpu, TensorMetrics::default(), false)?;
-        let mut runner_wgpu = Llama2Runner::new(&model_wgpu, TensorMetrics::default(), false)?;
+        let mut runner_cpu = Llama2Runner::new(&model_cpu, TensorMetrics::default(), 200, false)?;
+        let mut runner_wgpu = Llama2Runner::new(&model_wgpu, TensorMetrics::default(), 200, false)?;
 
         let output_cpu = runner_cpu
             .generate("Lily is a cat", 30, &mut sampler)?


### PR DESCRIPTION
When calculating attentions, we encounter two shapes:

1. dot_product(matrix row, vector)
2. dot_product(matrix column, vector)

The first is inherently cache-friendly.

the second is not; however, we can consider the matmul as a interations of fused multiply-add operations.

```
for mi in 0..m {
    c[mi] += a[a_offset + mi] * b;
}
```

this iteration could also be considered cache friendly, and in my benchmarks, this FMA iterations performs exactly same as the DOTPRODUCT iterations.