### PR TITLE
optimize: allocating f16 kv cache

### DIFF
--- a/crabml-core/src/backends/cpu/buf/buf_f16.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_f16.rs
@@ -16,6 +16,25 @@ pub fn f16_buf_from_bytes<'a>(buf: &[u8]) -> Cow<'a, [f16]> {
     f16_buf.into()
 }
 
+// it's slow to initialize a vec![f16::ZERO; buf_size], nearly 80~200ms on preparing kv cache.
+// we can initialize a vec![0 as u16; buf_size] and reinterpret it into Vec<f16> to make it 
+// faster, please note that the zerod f16 is not f16::ZERO, but f16(0x0000), do not read the
+// uninitialized data in this buf.
+// the code is modified from half's reinterpret_into function.
+pub fn alloc_f16_buf(len: usize) -> Vec<f16> {
+    let mut vec_u16 = vec![0; len];
+    let length = vec_u16.len();
+    let capacity = vec_u16.capacity();
+    let pointer = vec_u16.as_mut_ptr() as *mut f16;
+
+    // Prevent running a destructor on the old Vec<u16>, so the pointer won't be deleted
+    std::mem::forget(vec_u16);
+    // Finally construct a new Vec<f16> from the raw pointer
+    // SAFETY: We are reconstructing full length and capacity of original vector,
+    // using its original pointer, and the size of elements are identical.
+    unsafe { Vec::from_raw_parts(pointer, length, capacity) }
+}
+
 pub fn dequantize_f16_buf(buf: &[f16], start: usize) -> impl Iterator<Item = f32> + '_ {
     buf.iter().skip(start).map(|x| x.to_f32())
 }

--- a/crabml-core/src/backends/cpu/buf/buf_f16.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_f16.rs
@@ -17,7 +17,7 @@ pub fn f16_buf_from_bytes<'a>(buf: &[u8]) -> Cow<'a, [f16]> {
 }
 
 // it's slow to initialize a vec![f16::ZERO; buf_size], nearly 80~200ms on preparing kv cache.
-// we can initialize a vec![0 as u16; buf_size] and reinterpret it into Vec<f16> to make it 
+// we can initialize a vec![0 as u16; buf_size] and reinterpret it into Vec<f16> to make it
 // faster, please note that the zerod f16 is not f16::ZERO, but f16(0x0000), do not read the
 // uninitialized data in this buf.
 // the code is modified from half's reinterpret_into function.

--- a/crabml-core/src/backends/cpu/cpu_tensor.rs
+++ b/crabml-core/src/backends/cpu/cpu_tensor.rs
@@ -159,7 +159,7 @@ impl<'a> Tensor for CpuTensor<'a> {
                 CpuTensorBuf::F32(vec)
             }
             GGMLType::F16 => {
-                // it's slow to initialize a vec![f16::ZERO; buf_size], nearly 200ms on preparing kv cache
+                // it's slow to initialize a vec![f16::ZERO; buf_size], nearly 80~200ms on preparing kv cache
                 let vec_u16 = vec![0 as u16; buf_size];
                 let vec_f16 = reinterpret_vec_f16(vec_u16);
                 let vec = Cow::Owned(vec_f16);

--- a/crabml-core/src/backends/cpu/cpu_tensor.rs
+++ b/crabml-core/src/backends/cpu/cpu_tensor.rs
@@ -1,12 +1,9 @@
 use std::borrow::Cow;
 
-use half::f16;
-use half::vec::HalfFloatVecExt;
-
-use super::buf::buf_f16::alloc_f16_buf;
-use super::CpuTensorDeviceRef;
+use crate::backends::cpu::buf::buf_f16::alloc_f16_buf;
 use crate::backends::cpu::buf::CpuTensorBuf;
 use crate::backends::cpu::primitives;
+use crate::backends::cpu::CpuTensorDeviceRef;
 use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::error::Result;

--- a/crabml-core/src/backends/cpu/cpu_tensor.rs
+++ b/crabml-core/src/backends/cpu/cpu_tensor.rs
@@ -1,4 +1,7 @@
+use std::borrow::Cow;
+
 use half::f16;
+use half::vec::HalfFloatVecExt;
 
 use super::CpuTensorDeviceRef;
 use crate::backends::cpu::buf::CpuTensorBuf;
@@ -121,6 +124,25 @@ impl<'a> CpuTensor<'a> {
     }
 }
 
+fn reinterpret_vec_f16(mut vec_u16: Vec<u16>) -> Vec<f16> {
+    // An f16 array has same length and capacity as u16 array
+    let length = vec_u16.len();
+    let capacity = vec_u16.capacity();
+
+    // Actually reinterpret the contents of the Vec<f16> as u16,
+    // knowing that structs are represented as only their members in memory,
+    // which is the u16 part of `f16(u16)`
+    let pointer = vec_u16.as_mut_ptr() as *mut f16;
+
+    // Prevent running a destructor on the old Vec<u16>, so the pointer won't be deleted
+    std::mem::forget(vec_u16);
+
+    // Finally construct a new Vec<f16> from the raw pointer
+    // SAFETY: We are reconstructing full length and capacity of original vector,
+    // using its original pointer, and the size of elements are identical.
+    unsafe { Vec::from_raw_parts(pointer, length, capacity) }
+}
+
 impl<'a> Tensor for CpuTensor<'a> {
     type Device = CpuTensorDeviceRef<'a>;
 
@@ -133,12 +155,15 @@ impl<'a> Tensor for CpuTensor<'a> {
         let _t = device.metrics.alloc_walltime.track();
         let buf = match dtype {
             GGMLType::F32 => {
-                let vec = vec![0.0; buf_size];
-                CpuTensorBuf::F32(vec.into())
+                let vec = Cow::Owned(vec![0.0; buf_size]);
+                CpuTensorBuf::F32(vec)
             }
             GGMLType::F16 => {
-                let vec = vec![f16::ZERO; buf_size];
-                CpuTensorBuf::F16(vec.into())
+                // it's slow to initialize a vec![f16::ZERO; buf_size], nearly 200ms on preparing kv cache
+                let vec_u16 = vec![0 as u16; buf_size];
+                let vec_f16 = reinterpret_vec_f16(vec_u16);
+                let vec = Cow::Owned(vec_f16);
+                CpuTensorBuf::F16(vec)
             }
             _ => unreachable!(),
         };


### PR DESCRIPTION
it seems that allocating `Vec<f16>` for kv cache is very slow (84ms~200ms), as it seems that it need some memset, as f16::ZERO is actually not a zero value.

this PR initialize a zero valued `Vec<u16>` instead, then reinterpret it to a `Vec<f16>`.

(please note that the zero memory value are not valid value for float numbers, we need set it as float before actually access it)