### PR TITLE
feat: optimization of rayon 's usage

### DIFF
--- a/crabml-core/src/backends/cpu/buf/buf_f32.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_f32.rs
@@ -150,8 +150,8 @@ fn vec_dot_f32_f32_strided_simd(
         for ki in (0..k_rounded_down).step_by(8) {
             let mut av_tmp = [0.0_f32; 8];
             // Load elements from 'a' with stride
-            for i in 0..8 {
-                av_tmp[i] = *a_ptr.add(ki * a_stride + i * a_stride);
+            for (i, av) in av_tmp.iter_mut().enumerate() {
+                *av = *a_ptr.add((ki + i) * a_stride);
             }
             let av = _mm256_loadu_ps(av_tmp.as_ptr());
             let bv = _mm256_loadu_ps(b.as_ptr().add(ki));

--- a/crabml-core/src/backends/cpu/primitives/batch_matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/batch_matmul_vec.rs
@@ -1,5 +1,4 @@
 use half::f16;
-use rayon::prelude::*;
 
 use crate::backends::cpu::buf::buf_f16::quantize_f32_f16;
 use crate::backends::cpu::buf::buf_f16::vec_dot_f16_f16;
@@ -77,7 +76,7 @@ fn batch_matmul_vec_f32(
     mi_stride: usize,
     ki_stride: usize,
 ) {
-    cbuf.par_iter_mut().enumerate().for_each(|(i, bufcp)| {
+    cbuf.iter_mut().enumerate().for_each(|(i, bufcp)| {
         let mi = i % m;
         let bi = (i - mi) / m;
         *bufcp = vec_dot_f32_f32_strided(
@@ -106,7 +105,7 @@ fn batch_matmul_vec_f16(
 ) {
     if a_stride2 == 1 {
         let _t = device.metrics.batch_matmul_rowwise_walltime.track();
-        cbuf.par_iter_mut().enumerate().for_each(|(i, bufcp)| {
+        cbuf.iter_mut().enumerate().for_each(|(i, bufcp)| {
             let mi = i % m;
             let bi = (i - mi) / m;
             *bufcp = f16::from_f32(vec_dot_f16_f16(


### PR DESCRIPTION
Test command is , 
```
time cargo run --release -- -m ./testdata/tinyllamas-stories-15m-q8_0.gguf "capatain america" --steps 1000 -t 0 -T 8
239.47566 tokens/s, 8 threads
```

The main branch on my  pc(x86_64, 48theads, epyc 7402,ubuntu22.04)
```
239.47566 tokens/s, 8 threads
cargo run --release -- -m ./testdata/tinyllamas-stories-15m-q8_0.gguf  --step  8.49s user 2.31s system 198% cpu 5.429 total
```
After gemv_simd's optimization
```
369.1034 tokens/s, 8 threads
cargo run --release -- -m ./testdata/tinyllamas-stories-15m-q8_0.gguf  --step  5.88s user 1.30s system 278% cpu 2.575 total
```
After remove  rayon usage in batch_matmul_vec.rs
```
523.69604 tokens/s, 8 threads
cargo run --release -- -m ./testdata/tinyllamas-stories-15m-q8_0.gguf  --step  4.94s user 0.71s system 114% cpu 4.928 total
```

Finally remove all metrics
```
545.6702 tokens/s, 8 threads
cargo run --release -- -m ./testdata/tinyllamas-stories-15m-q8_0.gguf  --step  4.92s user 0.64s system 114% cpu 4.831 total
```

The final's perf stat
```
          1,487.73 msec task-clock                       #    2.305 CPUs utilized             
             4,024      context-switches                 #    2.705 K/sec                     
                21      cpu-migrations                   #   14.115 /sec                      
            10,573      page-faults                      #    7.107 K/sec                     
     2,689,111,864      cycles                           #    1.808 GHz                         (82.84%)
        69,343,582      stalled-cycles-frontend          #    2.58% frontend cycles idle        (83.34%)
     1,184,057,014      stalled-cycles-backend           #   44.03% backend cycles idle         (80.84%)
     6,605,465,686      instructions                     #    2.46  insn per cycle            
                                                  #    0.18  stalled cycles per insn     (84.52%)
       597,735,473      branches                         #  401.777 M/sec                       (85.22%)
         9,240,756      branch-misses                    #    1.55% of all branches             (83.27%)

       0.645322441 seconds time elapsed

       1.116548000 seconds user
       0.370657000 seconds sys
```
