### PR TITLE
refactor: optimize f16 buf alloc with unsafe set_len

### DIFF
--- a/crabml-core/src/backends/cpu/buf/buf_f16.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_f16.rs
@@ -20,6 +20,7 @@ pub fn f16_buf_from_bytes<'a>(buf: &[u8]) -> Cow<'a, [f16]> {
 // we can initialize a vec![0 as u16; buf_size] and reinterpret it into Vec<f16> to make it
 // faster, please note that the zerod f16 is not f16::ZERO, but f16(0x0000), do not read the
 // uninitialized data in this buf.
+#[expect(clippy::uninit_vec)]
 pub fn alloc_f16_buf(len: usize) -> Vec<f16> {
     let mut buf = Vec::with_capacity(len);
     unsafe { buf.set_len(len) };

--- a/crabml-core/src/backends/cpu/buf/buf_f16.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_f16.rs
@@ -20,19 +20,10 @@ pub fn f16_buf_from_bytes<'a>(buf: &[u8]) -> Cow<'a, [f16]> {
 // we can initialize a vec![0 as u16; buf_size] and reinterpret it into Vec<f16> to make it
 // faster, please note that the zerod f16 is not f16::ZERO, but f16(0x0000), do not read the
 // uninitialized data in this buf.
-// the code is modified from half's reinterpret_into function.
 pub fn alloc_f16_buf(len: usize) -> Vec<f16> {
-    let mut vec_u16 = vec![0; len];
-    let length = vec_u16.len();
-    let capacity = vec_u16.capacity();
-    let pointer = vec_u16.as_mut_ptr() as *mut f16;
-
-    // Prevent running a destructor on the old Vec<u16>, so the pointer won't be deleted
-    std::mem::forget(vec_u16);
-    // Finally construct a new Vec<f16> from the raw pointer
-    // SAFETY: We are reconstructing full length and capacity of original vector,
-    // using its original pointer, and the size of elements are identical.
-    unsafe { Vec::from_raw_parts(pointer, length, capacity) }
+    let mut buf = Vec::with_capacity(len);
+    unsafe { buf.set_len(len) };
+    buf
 }
 
 pub fn dequantize_f16_buf(buf: &[f16], start: usize) -> impl Iterator<Item = f32> + '_ {

--- a/crabml-core/src/lib.rs
+++ b/crabml-core/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(thread_local)]
 #![feature(lazy_cell)]
 #![feature(iter_array_chunks)]
+#![feature(lint_reasons)]
 
 #[allow(unreachable_patterns)]
 pub mod backends;


### PR DESCRIPTION
- Simplify dirty f16 buffer allocation.
- Fix the double-sized buffer bug. (For there is no type hint when creating a u16 vec, the buffer will be created as i32 vec by default.)

Benchmark code and result: https://gist.github.com/MrCroxx/767ab7bd3022b6991dd502d39d9ba5dc .