### PR TITLE
optimize: use a vanilla thread pool

### DIFF
--- a/crabml-cli/src/main.rs
+++ b/crabml-cli/src/main.rs
@@ -144,15 +144,10 @@ fn main() -> Result<()> {
     let args = CommandArgs::parse();
     let start_time = Instant::now();
 
-    // configure rayon
     let mut thread_num = args.threads;
     if thread_num == 0 {
         thread_num = num_cpus::get();
     }
-    rayon::ThreadPoolBuilder::new()
-        .num_threads(thread_num)
-        .build_global()
-        .unwrap();
 
     let gl = GGUFFileLoader::new(&args.model)?;
     let gf = gl.open()?;

--- a/crabml-core/Cargo.toml
+++ b/crabml-core/Cargo.toml
@@ -20,6 +20,7 @@ byteorder = "1.5.0"
 scoped_threadpool = "0.1.9"
 crossbeam-channel = "0.5"
 crossbeam-utils = "0.8"
+quanta = "0.12.2"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/crabml-core/Cargo.toml
+++ b/crabml-core/Cargo.toml
@@ -9,7 +9,6 @@ description = "crabml core package"
 [dependencies]
 int-enum = "0.5.0"
 memmap2 = "0.7.1"
-rayon = "1"
 half = { version = "2.3.1" }
 matrixmultiply = { version = "0.3", default-features = false }
 wgpu = "0.19.1"
@@ -17,10 +16,7 @@ env_logger = "0.10"
 pollster = "0.2.4"
 bytemuck = { version = "1.14.0", features = ["derive"] }
 byteorder = "1.5.0"
-scoped_threadpool = "0.1.9"
 crossbeam-channel = "0.5"
-crossbeam-utils = "0.8"
-quanta = "0.12.2"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/crabml-core/Cargo.toml
+++ b/crabml-core/Cargo.toml
@@ -17,6 +17,9 @@ env_logger = "0.10"
 pollster = "0.2.4"
 bytemuck = { version = "1.14.0", features = ["derive"] }
 byteorder = "1.5.0"
+scoped_threadpool = "0.1.9"
+crossbeam-channel = "0.5"
+crossbeam-utils = "0.8"
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/crabml-core/src/backends/cpu/cpu_device.rs
+++ b/crabml-core/src/backends/cpu/cpu_device.rs
@@ -23,7 +23,6 @@ pub struct CpuTensorDevice<'a> {
     pub(crate) opts: CpuTensorDeviceOptions,
     pub(crate) metrics: TensorMetrics,
     pub(crate) debug_tensors: RefCell<HashMap<String, Vec<f32>>>,
-    pub(crate) wbuf: RefCell<Option<Vec<f32>>>,
     pub(crate) exp_cache: Rc<Vec<f16>>,
     _phantom: std::marker::PhantomData<&'a ()>,
 }
@@ -36,7 +35,6 @@ impl<'a> CpuTensorDevice<'a> {
             opts: CpuTensorDeviceOptions::default(),
             debug_tensors: RefCell::new(HashMap::new()),
             metrics: TensorMetrics::default(),
-            wbuf: RefCell::new(Some(vec![0.0; 32000])),
             exp_cache: Rc::new(Self::init_exp_cache()),
             _phantom: std::marker::PhantomData,
         };
@@ -48,8 +46,7 @@ impl<'a> CpuTensorDevice<'a> {
         let device = Self {
             opts,
             debug_tensors: RefCell::new(HashMap::new()),
-            metrics: metrics,
-            wbuf: RefCell::new(Some(vec![0.0; 32000])),
+            metrics,
             exp_cache: Rc::new(Self::init_exp_cache()),
             _phantom: std::marker::PhantomData,
         };

--- a/crabml-core/src/backends/cpu/cpu_device.rs
+++ b/crabml-core/src/backends/cpu/cpu_device.rs
@@ -7,7 +7,7 @@ use half::f16;
 use super::CpuTensor;
 use crate::tensor::TensorMetrics;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct CpuTensorDeviceOptions {
     /// when enabled, whenever tensor called with `with_name`, the name and the
     /// tensor will be recorded in the device. only used in test.
@@ -16,6 +16,33 @@ pub struct CpuTensorDeviceOptions {
     pub metrics: TensorMetrics,
 
     pub thread_num: usize,
+}
+
+impl Default for CpuTensorDeviceOptions {
+    fn default() -> Self {
+        Self {
+            debug_named_tensors: false,
+            metrics: TensorMetrics::default(),
+            thread_num: 1,
+        }
+    }
+}
+
+impl CpuTensorDeviceOptions {
+    pub fn with_thread_num(mut self, thread_num: usize) -> Self {
+        self.thread_num = thread_num;
+        self
+    }
+
+    pub fn with_debug_named_tensors(mut self, debug_named_tensors: bool) -> Self {
+        self.debug_named_tensors = debug_named_tensors;
+        self
+    }
+
+    pub fn with_metrics(mut self, metrics: TensorMetrics) -> Self {
+        self.metrics = metrics;
+        self
+    }
 }
 
 #[derive(Debug)]
@@ -31,14 +58,8 @@ pub type CpuTensorDeviceRef<'a> = Rc<CpuTensorDevice<'a>>;
 
 impl<'a> CpuTensorDevice<'a> {
     pub fn new() -> CpuTensorDeviceRef<'a> {
-        let device = Self {
-            opts: CpuTensorDeviceOptions::default(),
-            debug_tensors: RefCell::new(HashMap::new()),
-            metrics: TensorMetrics::default(),
-            exp_cache: Rc::new(Self::init_exp_cache()),
-            _phantom: std::marker::PhantomData,
-        };
-        Rc::new(device)
+        let opts = CpuTensorDeviceOptions::default();
+        Self::with_options(opts)
     }
 
     pub fn with_options(opts: CpuTensorDeviceOptions) -> CpuTensorDeviceRef<'a> {

--- a/crabml-core/src/backends/cpu/cpu_tensor.rs
+++ b/crabml-core/src/backends/cpu/cpu_tensor.rs
@@ -377,7 +377,7 @@ impl<'a> Tensor for CpuTensor<'a> {
         let bufc = c.buf_mut();
         let strider1 = self.strider();
         let strider2 = x.strider();
-        let _t = self.device.metrics.matmul_walltime.track();
+        // let _t = self.device.metrics.matmul_walltime.track();
         primitives::matmul_vec(&self.device, bufa, bufb, bufc, strider1, strider2);
         Ok(c)
     }

--- a/crabml-core/src/backends/cpu/cpu_tensor.rs
+++ b/crabml-core/src/backends/cpu/cpu_tensor.rs
@@ -377,7 +377,7 @@ impl<'a> Tensor for CpuTensor<'a> {
         let bufc = c.buf_mut();
         let strider1 = self.strider();
         let strider2 = x.strider();
-        // let _t = self.device.metrics.matmul_walltime.track();
+        let _t = self.device.metrics.matmul_walltime.track();
         primitives::matmul_vec(&self.device, bufa, bufb, bufc, strider1, strider2);
         Ok(c)
     }

--- a/crabml-core/src/backends/cpu/mod.rs
+++ b/crabml-core/src/backends/cpu/mod.rs
@@ -3,6 +3,7 @@ pub mod buf;
 mod cpu_device;
 mod cpu_tensor;
 mod primitives;
+mod thread_pool;
 
 pub use buf::CpuTensorBuf;
 pub use cpu_device::CpuTensorDevice;

--- a/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
@@ -45,6 +45,8 @@ fn gemv_dense_2d_2d(
     let chunk_size = 16;
     assert!(split_size % chunk_size == 0);
 
+    let _t = device.metrics.matmul_walltime.track();
+
     POOL.lock().unwrap().scoped(|s| {
         bufc.chunks_exact_mut(split_size)
             .enumerate()

--- a/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
@@ -40,6 +40,7 @@ fn gemv_dense_2d_2d(
 ) {
     let bufc = bufc.as_f32_mut();
     let bufb = &bufb.quantize(bufa.vec_dot_rhs_dtype()).unwrap();
+    let thread_num = device.thread_num();
     let split_size = bufc.len() / 2;
     let chunk_size = 16;
     assert!(split_size % chunk_size == 0);

--- a/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
@@ -41,7 +41,7 @@ fn gemv_dense_2d_2d(
     let bufc = bufc.as_f32_mut();
     let bufb = &bufb.quantize(bufa.vec_dot_rhs_dtype()).unwrap();
     let thread_num = device.thread_num();
-    let split_size = bufc.len() / 2;
+    let split_size = bufc.len() / thread_num;
     let chunk_size = 16;
     assert!(split_size % chunk_size == 0);
 

--- a/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
@@ -2,8 +2,6 @@ use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::time::Instant;
 
-use rayon::prelude::*;
-
 use crate::backends::cpu::buf::CpuTensorBuf;
 use crate::backends::cpu::thread_pool::ThreadPool;
 use crate::backends::cpu::CpuTensorDeviceRef;
@@ -85,6 +83,6 @@ fn gemv_dense_2d_2d(
         .max_by(|a, b| a.partial_cmp(b).unwrap())
         .unwrap();
     metrics
-        .matmuL_non_compute_walltime
+        .matmul_non_compute_walltime
         .increment_nanos(total_time.as_nanos() - max_thread_nanos);
 }

--- a/crabml-core/src/backends/cpu/thread_pool.rs
+++ b/crabml-core/src/backends/cpu/thread_pool.rs
@@ -42,7 +42,8 @@ impl ThreadPool {
         f(&mut scope);
 
         let wg = crossbeam_utils::sync::WaitGroup::new();
-        for (i, thunk) in scope.into_inner().into_iter().enumerate() {
+        let thunks_iter = scope.into_inner().into_iter();
+        for (i, thunk) in thunks_iter.enumerate() {
             let work = (thunk, wg.clone());
             let thread_idx = i % self.senders.len();
             self.senders[thread_idx].send(work).unwrap();

--- a/crabml-core/src/backends/cpu/thread_pool.rs
+++ b/crabml-core/src/backends/cpu/thread_pool.rs
@@ -1,5 +1,6 @@
 use std::mem;
 use std::sync::mpsc;
+use std::time::Instant;
 
 type Thunk<'a> = Box<dyn FnOnce() + Send + 'a>;
 

--- a/crabml-core/src/backends/cpu/thread_pool.rs
+++ b/crabml-core/src/backends/cpu/thread_pool.rs
@@ -1,0 +1,70 @@
+use std::mem;
+use std::sync::mpsc;
+
+type Thunk<'a> = Box<dyn FnOnce() + Send + 'a>;
+
+type Work = (Thunk<'static>, crossbeam_utils::sync::WaitGroup);
+
+/// A threadpool that acts as a handle to a number
+/// of threads spawned at construction.
+pub struct ThreadPool {
+    senders: Vec<mpsc::Sender<Work>>,
+}
+
+impl ThreadPool {
+    /// Construct a threadpool with the given number of threads.
+    /// Minimum value is `1`.
+    pub fn new(n: usize) -> Self {
+        assert!(n >= 1);
+
+        let mut senders = vec![];
+        for _ in 0..n {
+            let (sender, receiver) = mpsc::channel::<Work>();
+            senders.push(sender);
+            std::thread::spawn(move || {
+                while let Ok((thunk, wg)) = receiver.recv() {
+                    thunk();
+                    drop(wg)
+                }
+            });
+        }
+
+        Self { senders }
+    }
+
+    pub fn scoped<'scope, F>(&self, f: F)
+    where F: FnOnce(&mut Scope<'scope>) + Send + 'scope {
+        let mut scope = Scope::<'scope> {
+            thunks: Vec::new(),
+            _phantom: std::marker::PhantomData,
+        };
+
+        f(&mut scope);
+
+        let wg = crossbeam_utils::sync::WaitGroup::new();
+        for (i, thunk) in scope.into_inner().into_iter().enumerate() {
+            let work = (thunk, wg.clone());
+            let thread_idx = i % self.senders.len();
+            self.senders[thread_idx].send(work).unwrap();
+        }
+
+        wg.wait();
+    }
+}
+
+pub struct Scope<'scope> {
+    thunks: Vec<Thunk<'static>>,
+    _phantom: std::marker::PhantomData<&'scope ()>,
+}
+
+impl<'scope> Scope<'scope> {
+    pub fn spawn<'a, F>(&mut self, f: F)
+    where F: FnOnce() + Send + 'a {
+        let b = unsafe { mem::transmute::<Thunk<'a>, Thunk<'static>>(Box::new(f)) };
+        self.thunks.push(b)
+    }
+
+    pub fn into_inner(self) -> Vec<Thunk<'static>> {
+        self.thunks
+    }
+}

--- a/crabml-core/src/backends/cpu/thread_pool.rs
+++ b/crabml-core/src/backends/cpu/thread_pool.rs
@@ -60,9 +60,12 @@ impl ThreadPool {
             self.senders[thread_idx].send(work).unwrap();
         }
 
+        // execute the first thunk in the current thread.
         first_thunk();
 
-        // await the rest of the thunks
+        // await the completion of the remaining thunks. a busy loop here appears to be faster than
+        // using crossbeam's WaitGroup. generating a token can trigger 100+ task coordination operations
+        // (using condvar inside), which might introduce an overhead about 2ms for each token generation.
         while counter.load(std::sync::atomic::Ordering::Relaxed) > 1 {}
     }
 }

--- a/crabml-core/src/backends/cpu/thread_pool.rs
+++ b/crabml-core/src/backends/cpu/thread_pool.rs
@@ -9,6 +9,7 @@ type Work = (Thunk<'static>, Arc<AtomicUsize>, Instant);
 
 /// A threadpool that acts as a handle to a number
 /// of threads spawned at construction.
+#[derive(Debug)]
 pub struct ThreadPool {
     senders: Vec<crossbeam_channel::Sender<Work>>,
 }

--- a/crabml-core/src/tensor/metrics.rs
+++ b/crabml-core/src/tensor/metrics.rs
@@ -12,7 +12,7 @@ pub struct TensorMetrics {
     pub softmax_walltime: TimeMetric,
     pub activate_walltime: TimeMetric,
     pub matmul_walltime: TimeMetric,
-    pub matmuL_non_compute_walltime: TimeMetric,
+    pub matmul_non_compute_walltime: TimeMetric,
     pub dequantize_walltime: TimeMetric,
     pub matmul_quantize_walltime: TimeMetric,
     pub batch_matmul_quantize_walltime: TimeMetric,
@@ -41,7 +41,7 @@ impl TensorMetrics {
         self.activate_walltime.reset();
         self.total_walltime.reset();
         self.matmul_quantize_walltime.reset();
-        self.matmuL_non_compute_walltime.reset();
+        self.matmul_non_compute_walltime.reset();
         self.batch_matmul_quantize_walltime.reset();
         self.export_walltime.reset();
         self.batch_matmul_walltime.reset();
@@ -136,7 +136,7 @@ impl TensorMetrics {
             ),
             (
                 "matmul_non_compute_walltime".to_string(),
-                self.matmuL_non_compute_walltime.as_millis(),
+                self.matmul_non_compute_walltime.as_millis(),
             ),
         ]
     }
@@ -164,7 +164,7 @@ impl TimeMetric {
     }
 
     pub fn as_nanos(&self) -> u64 {
-        self.inner.load(std::sync::atomic::Ordering::Relaxed) as u64
+        self.inner.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub fn as_millis(&self) -> f64 {

--- a/crabml-core/src/tensor/metrics.rs
+++ b/crabml-core/src/tensor/metrics.rs
@@ -12,6 +12,7 @@ pub struct TensorMetrics {
     pub softmax_walltime: TimeMetric,
     pub activate_walltime: TimeMetric,
     pub matmul_walltime: TimeMetric,
+    pub matmuL_non_compute_walltime: TimeMetric,
     pub dequantize_walltime: TimeMetric,
     pub matmul_quantize_walltime: TimeMetric,
     pub batch_matmul_quantize_walltime: TimeMetric,
@@ -40,6 +41,7 @@ impl TensorMetrics {
         self.activate_walltime.reset();
         self.total_walltime.reset();
         self.matmul_quantize_walltime.reset();
+        self.matmuL_non_compute_walltime.reset();
         self.batch_matmul_quantize_walltime.reset();
         self.export_walltime.reset();
         self.batch_matmul_walltime.reset();
@@ -132,6 +134,10 @@ impl TensorMetrics {
                 "contiguous_walltime".to_string(),
                 self.contiguous_walltime.as_millis(),
             ),
+            (
+                "matmul_non_compute_walltime".to_string(),
+                self.matmuL_non_compute_walltime.as_millis(),
+            ),
         ]
     }
 }
@@ -157,8 +163,17 @@ impl TimeMetric {
         self.inner.store(0, std::sync::atomic::Ordering::Relaxed);
     }
 
+    pub fn as_nanos(&self) -> u64 {
+        self.inner.load(std::sync::atomic::Ordering::Relaxed) as u64
+    }
+
     pub fn as_millis(&self) -> f64 {
         self.inner.load(std::sync::atomic::Ordering::Relaxed) as f64 / 1000000.0
+    }
+
+    pub fn increment_nanos(self, ns: u64) {
+        self.inner
+            .fetch_add(ns, std::sync::atomic::Ordering::Relaxed);
     }
 
     pub fn track(&self) -> TimeMetricGuard {

--- a/crabml-llama2/Cargo.toml
+++ b/crabml-llama2/Cargo.toml
@@ -9,7 +9,6 @@ description = "crabml llama2 support"
 [dependencies]
 memmap2 = "0.7.1"
 rand = "0.8.5"
-rayon = "1"
 num_cpus = "1.16.0"
 crabml = { workspace = true }
 half = { version = "2.3.1" }

--- a/crabml-llama2/src/llama2.rs
+++ b/crabml-llama2/src/llama2.rs
@@ -382,7 +382,7 @@ impl<'a, T: Tensor> Llama2Runner<T> {
             // (n_head, n_batch, seq) @ (n_kv_heads, seq, head_dim) => (n_head, n_batch, head_dim)
             let x_with_attn = attn.batch_matmul(&v_cache)?; // (n_heads, n_batch, head_dim)
             let x_with_attn = if n_batch == 1 {
-                // TODO: this special case might be able to unify with the general case
+                // TODO: this specialase might be able to unify with the general case
                 x_with_attn.reshape(&[n_batch, embed_dim])?
             } else {
                 x_with_attn

--- a/crabml-llama2/src/llama2.rs
+++ b/crabml-llama2/src/llama2.rs
@@ -382,6 +382,7 @@ impl<'a, T: Tensor> Llama2Runner<T> {
             // (n_head, n_batch, seq) @ (n_kv_heads, seq, head_dim) => (n_head, n_batch, head_dim)
             let x_with_attn = attn.batch_matmul(&v_cache)?; // (n_heads, n_batch, head_dim)
             let x_with_attn = if n_batch == 1 {
+                // TODO: this special case might be able to unify with the general case
                 x_with_attn.reshape(&[n_batch, embed_dim])?
             } else {
                 x_with_attn

--- a/crabml-llama2/src/llama2.rs
+++ b/crabml-llama2/src/llama2.rs
@@ -452,9 +452,7 @@ mod tests {
             GGUFFileLoader::new("../testdata/tinyllamas-stories-15m-f32.gguf")?;
         let gf = gl.open()?;
 
-        let device = CpuTensorDevice::with_options(CpuTensorDeviceOptions {
-            debug_named_tensors: false,
-        });
+        let device = CpuTensorDevice::with_options(CpuTensorDeviceOptions::default());
         let lm = CpuLlama2Model::load(&gf, device.clone())?;
 
         let mut sampler = Llama2Sampler::new(lm.conf.vocab_size, 0.0, 0.0, device.exp_cache());
@@ -529,9 +527,9 @@ mod tests {
             GGUFFileLoader::new("../testdata/tinyllamas-stories-15m-f32.gguf")?;
         let gf = gl.open()?;
 
-        let device_cpu = CpuTensorDevice::with_options(CpuTensorDeviceOptions {
-            debug_named_tensors: true,
-        });
+        let device_cpu = CpuTensorDevice::with_options(
+            CpuTensorDeviceOptions::default().with_debug_named_tensors(true),
+        );
         let model_cpu = CpuLlama2Model::load(&gf, device_cpu.clone())?;
 
         let device_wgpu = WgpuTensorDevice::new(


### PR DESCRIPTION
~the performance on matmul improved on 1 thread but degrated on 2 threads, while it also utilized the current thread to compute. 🤔~

after replaced crossbeam's waitgroup with a busy loop, it seems worked.

- [x] add a vanilla thread pool in matmul
- [x] add thread pool into cpu device
- [x] ~limit the threads num to be exp of 2~ allow use odd threads numbers
- [ ] use thread pool in attentions (maybe in another PR)