### PR TITLE
refactor: simplify q8_1 quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,21 @@ For more information, you can visit [How to Get GGUF Models](https://github.com/
 
 ## Supported Quantization Methods
 
-`crabml` supports the following quantization methods on the CPU:
+`crabml` supports the following quantization methods on the CPU with SIMD acceleration on ARM and x86 architectures.  Q8_0 and Q4_0 are the most suggested quantization methods yet!
 
-- 8 bits: Q8_0, Q8_1
-- 6 bits: Q6_K
-- 5 bits: Q5_0, Q5_1, Q5_k
-- 4 bits: Q4_0, Q4_1, Q4_k
-- 3 bits: Q3_k
-- 2 bits: Q2_k
+While the WebGPU accelerated quantizations are under development, still not available yet.
 
-The GPU quantization support is on the way!
+|      | Bits   | Supported | NEON | AVX2 | WebGPU |
+| Q8_0 | 8 bits | ✅         | ✅   | ✅   | WIP    |
+| Q6_K | 6 bits | ✅         | WIP  | WIP   | WIP  |
+| Q5_0 | 5 bits | ✅         | WIP  | WIP   | WIP  |
+| Q5_1 | 5 bits | ✅         | WIP  | WIP   | WIP  |
+| Q5_K | 5 bits | ✅         | WIP  | WIP   | WIP  |
+| Q4_0 | 4 bits | ✅         | ✅   | WIP   |  WIP  |
+| Q4_1 | 4 bits | ✅         | ✅   | ✅    | WIP    |
+| Q4_K | 4 bits | ✅         | WIP   | WIP    | WIP    |
+| Q3_K | 3 bits | ✅         | WIP   | WIP    | WIP    |
+| Q2_K | 2 bits | ✅         | WIP   | WIP    | WIP    |
 
 ## Usage
 

--- a/crabml-core/src/backends/cpu/buf/buf_q4_0.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_q4_0.rs
@@ -188,19 +188,16 @@ pub fn vec_dot_q4_0_q8_0_neon(abs: &[BlockQ4_0], bbs: &[BlockQ8_0]) -> f32 {
     };
 
     // handle the remaining blocks, it seems that only tinyllamas has the case where n_blocks % 2 != 0
-    for i in n_blocks_rounded..n_blocks {
-        let mut sumi = 0;
-        for j in 0..16 {
-            let v0 = (abs[i].qs[j] & 0x0F) as i32 - 8;
-            let v1 = (abs[i].qs[j] >> 4) as i32 - 8;
-            sumi += v0 * bbs[i].qs[j] as i32 + v1 * bbs[i].qs[j + 16] as i32
-        }
-        sumf += sumi as f32 * f16::to_f32(abs[i].d) * f16::to_f32(bbs[i].d);
+    if n_blocks > n_blocks_rounded {
+        sumf += vec_dot_q4_0_q8_0_fallback(
+            &abs[n_blocks_rounded..n_blocks],
+            &bbs[n_blocks_rounded..n_blocks],
+        );
     }
+
     sumf
 }
 
-#[allow(unused)]
 pub fn vec_dot_q4_0_q8_0_fallback(abs: &[BlockQ4_0], bbs: &[BlockQ8_0]) -> f32 {
     let mut sumf: f32 = 0f32;
     for i in 0..bbs.len() {

--- a/crabml-core/src/backends/cpu/buf/buf_q4_1.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_q4_1.rs
@@ -193,16 +193,13 @@ pub fn vec_dot_q4_1_q8_1_neon(abs: &[BlockQ4_1], bbs: &[BlockQ8_1]) -> f32 {
     };
 
     // handle the remaining blocks, it seems that only tinyllamas has the case where n_blocks % 2 != 0
-    for i in n_blocks_rounded..n_blocks {
-        let mut sumi = 0;
-        for j in 0..16 {
-            let v0 = (abs[i].qs[j] & 0x0F) as i32;
-            let v1 = ((abs[i].qs[j] >> 4) & 0x0F) as i32;
-
-            sumi += v0 * bbs[i].qs[j] as i32 + v1 * bbs[i].qs[j + 16] as i32;
-        }
-        sumf += (abs[i].d * bbs[i].d).to_f32() * sumi as f32 + (abs[i].m * bbs[i].s).to_f32();
+    if n_blocks > n_blocks_rounded {
+        sumf += vec_dot_q4_1_q8_1_fallback(
+            &abs[n_blocks_rounded..n_blocks],
+            &bbs[n_blocks_rounded..n_blocks],
+        );
     }
+
     sumf
 }
 
@@ -245,16 +242,13 @@ pub fn vec_dot_q4_1_q8_1_avx2(abs: &[BlockQ4_1], bbs: &[BlockQ8_1]) -> f32 {
     };
 
     // handle the remaining blocks, it seems that only tinyllamas has the case where n_blocks % 2 != 0
-    for i in n_blocks_rounded..n_blocks {
-        let mut sumi = 0;
-        for j in 0..16 {
-            let v0 = (abs[i].qs[j] & 0x0F) as i32;
-            let v1 = ((abs[i].qs[j] >> 4) & 0x0F) as i32;
-
-            sumi += v0 * bbs[i].qs[j] as i32 + v1 * bbs[i].qs[j + 16] as i32;
-        }
-        sumf += (abs[i].d.to_f32() * bbs[i].d) * sumi as f32 + abs[i].m.to_f32() * bbs[i].s;
+    if n_blocks > n_blocks_rounded {
+        sumf += vec_dot_q4_1_q8_1_fallback(
+            &abs[n_blocks_rounded..n_blocks],
+            &bbs[n_blocks_rounded..n_blocks],
+        );
     }
+
     sumf
 }
 

--- a/crabml-core/src/backends/cpu/buf/buf_q4_1.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_q4_1.rs
@@ -152,7 +152,7 @@ pub fn vec_dot_q4_1_q8_1_neon(abs: &[BlockQ4_1], bbs: &[BlockQ8_1]) -> f32 {
             let bb0 = bbs.get_unchecked(i);
             let bb1 = bbs.get_unchecked(i + 1);
 
-            summs += f16::to_f32(ab0.m) * bb0.s + f16::to_f32(ab1.m) * bb1.s;
+            summs += (ab0.m * bb0.s + ab1.m * bb1.s).to_f32();
 
             let m4b = vdupq_n_u8(0x0F);
 
@@ -178,7 +178,7 @@ pub fn vec_dot_q4_1_q8_1_neon(abs: &[BlockQ4_1], bbs: &[BlockQ8_1]) -> f32 {
                     vdotq_s32(zerov, v0_0l, v1_0l),
                     vdotq_s32(zerov, v0_0h, v1_0h),
                 )),
-                f16::to_f32(ab0.d) * bb0.d,
+                (ab0.d * bb0.d).to_f32(),
             );
             sumv1 = vmlaq_n_f32(
                 sumv1,
@@ -186,7 +186,7 @@ pub fn vec_dot_q4_1_q8_1_neon(abs: &[BlockQ4_1], bbs: &[BlockQ8_1]) -> f32 {
                     vdotq_s32(zerov, v0_1l, v1_1l),
                     vdotq_s32(zerov, v0_1h, v1_1h),
                 )),
-                f16::to_f32(ab1.d) * bb1.d,
+                (ab1.d * bb1.d).to_f32(),
             );
         }
         vaddvq_f32(sumv0) + vaddvq_f32(sumv1) + summs
@@ -201,7 +201,7 @@ pub fn vec_dot_q4_1_q8_1_neon(abs: &[BlockQ4_1], bbs: &[BlockQ8_1]) -> f32 {
 
             sumi += v0 * bbs[i].qs[j] as i32 + v1 * bbs[i].qs[j + 16] as i32;
         }
-        sumf += (abs[i].d.to_f32() * bbs[i].d) * sumi as f32 + abs[i].m.to_f32() * bbs[i].s;
+        sumf += (abs[i].d * bbs[i].d).to_f32() * sumi as f32 + (abs[i].m * bbs[i].s).to_f32();
     }
     sumf
 }
@@ -269,7 +269,7 @@ pub fn vec_dot_q4_1_q8_1_fallback(abs: &[BlockQ4_1], bbs: &[BlockQ8_1]) -> f32 {
 
             sumi += v0 * bbs[i].qs[j] as i32 + v1 * bbs[i].qs[j + 16] as i32;
         }
-        sumf += (abs[i].d.to_f32() * bbs[i].d) * sumi as f32 + abs[i].m.to_f32() * bbs[i].s;
+        sumf += (abs[i].d * bbs[i].d).to_f32() * sumi as f32 + (abs[i].m * bbs[i].s).to_f32();
     }
 
     sumf

--- a/crabml-core/src/backends/cpu/buf/buf_q4_1.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_q4_1.rs
@@ -252,7 +252,6 @@ pub fn vec_dot_q4_1_q8_1_avx2(abs: &[BlockQ4_1], bbs: &[BlockQ8_1]) -> f32 {
     sumf
 }
 
-#[allow(unused)]
 pub fn vec_dot_q4_1_q8_1_fallback(abs: &[BlockQ4_1], bbs: &[BlockQ8_1]) -> f32 {
     let mut sumf = 0f32;
     for i in 0..abs.len() {

--- a/crabml-core/src/backends/cpu/buf/buf_q5_1.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_q5_1.rs
@@ -148,7 +148,7 @@ pub fn vec_dot_q5_1_q8_1(abs: &[BlockQ5_1], bbs: &[BlockQ8_1]) -> f32 {
 
             sumi += (x0 * bbs[i].qs[j] as i32) + (x1 * bbs[i].qs[j + 16] as i32);
         }
-        sumf += sumi as f32 * f16::to_f32(abs[i].d) * bbs[i].d + f16::to_f32(abs[i].m) * bbs[i].s
+        sumf += sumi as f32 * (abs[i].d * bbs[i].d).to_f32() + (abs[i].m * bbs[i].s).to_f32();
     }
 
     sumf

--- a/crabml-core/src/backends/cpu/buf/buf_q8_1.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_q8_1.rs
@@ -129,47 +129,27 @@ mod tests {
     fn test_q8_1_block() {
         assert_eq!(
             std::mem::size_of::<BlockQ8_1>(),
-            2 * std::mem::size_of::<f32>() + 32,
+            2 * std::mem::size_of::<f16>() + 32,
             "wrong q8_1 block size/padding"
         );
-
         let mut buf: [u8; 80] = [0x1; 80];
 
-        let d_bytes = f32::to_le_bytes(3.0);
-        let s_bytes = f32::to_le_bytes(96.0);
-        buf[0..4].copy_from_slice(&d_bytes);
-        buf[4..8].copy_from_slice(&s_bytes);
+        let d_bytes = f16::from_f32(3.0).to_le_bytes();
+        let s_bytes = f16::from_f32(96.0).to_le_bytes();
+        buf[0..2].copy_from_slice(&d_bytes);
+        buf[2..4].copy_from_slice(&s_bytes);
 
-        buf[8] = 2;
-        buf[9] = 3;
-        buf[10] = 4;
-        buf[39] = 7;
+        buf[5] = 2;
+        buf[6] = 3;
+        buf[7] = 4;
+        buf[35] = 7;
 
-        buf[40..44].copy_from_slice(&d_bytes);
-        buf[44..48].copy_from_slice(&s_bytes);
-
-        buf[48] = 2;
-        buf[49] = 3;
-        buf[50] = 4;
-        buf[79] = 7;
-
-        let blocks = QuantBufQ8_1::from_bytes(&buf[0..40]).blocks;
+        let blocks = QuantBufQ8_1::from_bytes(&buf[0..36]).blocks;
         assert_eq!(blocks[0].d.to_f32(), 3.0);
         assert_eq!(blocks[0].s.to_f32(), 96.0);
         assert_eq!(blocks[0].qs, [
-            2, 3, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 2, 3, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 7
-        ]);
-
-        let bf = QuantBufQ8_1::from_bytes(&buf);
-
-        assert_eq!(bf.len(), 64);
-
-        assert_eq!(bf.dequantize(0).collect::<Vec<_>>(), vec![
-            6.0, 9.0, 12.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0,
-            3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 21.0, 6.0, 9.0,
-            12.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0,
-            3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 21.0
         ]);
     }
 }

--- a/crabml-core/src/backends/cpu/buf/buf_q8_1.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_q8_1.rs
@@ -1,5 +1,15 @@
 use std::borrow::Cow;
 
+use half::f16;
+
+/// Q8_1 is only used as intermediate format for matmul on Q4_1, Q5_1 quantization. There's no need to implement
+/// vec_dot for Q8_1. Compare to Q8_0, Q8_1 adds an extra `sum(d * qs[i])` value to the dot product
+/// calculation. Take Q4_1 as example, it adds an extra `min` value than Q4_0. So calculating the dot product
+/// of Q4_1 and Q8_1 is:
+/// (a[0] - min) * b[0] * a.d * b.d + ... + (a[31] - min) * b[31] * a.d * b.d
+/// = a[0] * b[0] * a.d * b.d + ... + a[31] * b[31] * a.d * b.d - min * (b[0] * a.d + ... + b[31] * a.d)
+/// = (a[0] * b[0] + a[1] * b[1] + ... a[31] * b[31]) * a.d * b.d + min * b.s
+/// = dot(a, b) * a.d * b.d + min * b.s
 #[derive(Debug, Clone)]
 pub struct QuantBufQ8_1<'a> {
     pub blocks: Cow<'a, [BlockQ8_1]>,
@@ -20,6 +30,7 @@ impl<'a> QuantBufQ8_1<'_> {
             blocks: blocks.into(),
         }
     }
+
     pub fn quantize(data: &[f32]) -> Self {
         let bs = quantize_f32_q8_1(data);
         Self { blocks: bs.into() }
@@ -59,383 +70,73 @@ impl<'a> QuantBufQ8_1<'_> {
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub struct BlockQ8_1 {
-    pub d: f32,       // delta
-    pub s: f32,       // d * sum(qs[i])
+    pub d: f16,       // delta
+    pub s: f16,       // d * sum(qs[i])
     pub qs: [i8; 32], // quants
 }
 
 impl BlockQ8_1 {
     pub fn dequantize(&self, buf: &mut [f32]) {
+        let d = f32::from(self.d);
         for (i, v) in buf.iter_mut().enumerate().take(32) {
-            *v = self.qs[i] as f32 * self.d;
+            *v = self.qs[i] as f32 * d;
         }
     }
 }
 
-#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-mod impl_aarch64_neon {
-    use std::arch::aarch64;
+pub fn quantize_f32_q8_1(data: &[f32]) -> Vec<BlockQ8_1> {
+    let mut bs = Vec::with_capacity(data.len() / 32);
 
-    use super::BlockQ8_1;
+    for chunk in data.chunks(32) {
+        let mut max_abs_value = 0.0;
 
-    pub fn quantize_f32_q8_1(data: &[f32]) -> Vec<BlockQ8_1> {
-        let mut bs = Vec::with_capacity(data.len() / 32);
-
-        unsafe {
-            for i in (0..data.len()).step_by(32) {
-                let mut vsrc = [aarch64::vdupq_n_f32(0.0); 8];
-                let mut vasrc = [aarch64::vdupq_n_f32(0.0); 8];
-                let mut vmax = [aarch64::vdupq_n_f32(0.0); 8];
-
-                for j in 0..8 {
-                    vsrc[j] = aarch64::vld1q_f32(data.as_ptr().add(i + j * 4));
-                    vasrc[j] = aarch64::vabsq_f32(vsrc[j]);
-                }
-
-                for j in 0..4 {
-                    vmax[2 * j] = aarch64::vmaxq_f32(vasrc[2 * j], vasrc[2 * j + 1]);
-                }
-                for j in 0..2 {
-                    vmax[4 * j] = aarch64::vmaxq_f32(vmax[4 * j], vmax[4 * j + 2]);
-                }
-                for j in 0..1 {
-                    vmax[8 * j] = aarch64::vmaxq_f32(vmax[8 * j], vmax[8 * j + 4]);
-                }
-                let max = aarch64::vmaxvq_f32(vmax[0]);
-
-                let d = max / 127.0;
-                let mut qs = [0_i8; 32];
-                let mut sum_qs = 0_f32;
-
-                for j in 0..8 {
-                    let v = aarch64::vdivq_f32(vsrc[j], aarch64::vdupq_n_f32(d));
-                    let vi = aarch64::vcvtq_s32_f32(v);
-                    let q = aarch64::vgetq_lane_s32(vi, 0) as i8;
-                    qs[4 * j] = q;
-                    sum_qs += q as f32;
-                    let q = aarch64::vgetq_lane_s32(vi, 1) as i8;
-                    qs[4 * j + 1] = q;
-                    sum_qs += q as f32;
-                    let q = aarch64::vgetq_lane_s32(vi, 2) as i8;
-                    qs[4 * j + 2] = q;
-                    sum_qs += q as f32;
-                    let q = aarch64::vgetq_lane_s32(vi, 3) as i8;
-                    qs[4 * j + 3] = q;
-                    sum_qs += q as f32;
-                }
-
-                bs.push(BlockQ8_1 {
-                    d,
-                    s: d * sum_qs,
-                    qs,
-                });
+        // Find the maximum absolute value in the chunk
+        for &value in chunk {
+            let abs_value = value.abs();
+            if abs_value > max_abs_value {
+                max_abs_value = abs_value;
             }
         }
 
-        bs
-    }
+        let d = max_abs_value / 127.0; // Compute the scaling factor
+        let mut qs = [0_i8; 32]; // Initialize the quantized values array
+        let mut s = 0f32; // Initialize the sum of scaled values
 
-    pub fn vec_dot_q8_1_q8_1(abs: &[BlockQ8_1], bbs: &[BlockQ8_1]) -> f32 {
-        if bbs.len() % 2 == 0 {
-            return vec_dot_q8_1_q8_1_neon_unrolled(abs, bbs);
+        // Quantize the chunk
+        for (i, &value) in chunk.iter().enumerate() {
+            let scaled_value = value / d; // Scale the value
+            // Convert the scaled value to i8, clamping it to the i8 range
+            let quantized_value = scaled_value.max(i8::MIN as f32).min(i8::MAX as f32) as i8;
+            qs[i] = quantized_value;
+            s += quantized_value as f32; // Accumulate the sum of quantized values
         }
-        vec_dot_q8_1_q8_1_neon(abs, bbs)
+
+        s *= d; // Multiply the sum by d to get the final value of s
+
+        // Store the block with the scaling factor, quantized values, and the sum
+        bs.push(BlockQ8_1 {
+            d: f16::from_f32(d),
+            s: f16::from_f32(s),
+            qs,
+        });
     }
 
-    fn vec_dot_q8_1_q8_1_neon(abs: &[BlockQ8_1], bbs: &[BlockQ8_1]) -> f32 {
-        assert!(abs.len() == bbs.len());
-
-        unsafe {
-            let mut sumv0 = aarch64::vdupq_n_f32(0.0);
-            let zerov = aarch64::vdupq_n_s32(0);
-
-            for i in 0..bbs.len() {
-                let ab0 = abs.get_unchecked(i);
-                let bb0 = bbs.get_unchecked(i);
-
-                let av00 = aarch64::vld1q_s8(ab0.qs.as_ptr());
-                let av01 = aarch64::vld1q_s8(ab0.qs.as_ptr().add(16));
-
-                let bv00 = aarch64::vld1q_s8(bb0.qs.as_ptr());
-                let bv01 = aarch64::vld1q_s8(bb0.qs.as_ptr().add(16));
-
-                sumv0 = aarch64::vmlaq_n_f32(
-                    sumv0,
-                    aarch64::vcvtq_f32_s32(aarch64::vaddq_s32(
-                        aarch64::vdotq_s32(zerov, av00, bv00),
-                        aarch64::vdotq_s32(zerov, av01, bv01),
-                    )),
-                    ab0.d * bb0.d,
-                );
-            }
-
-            aarch64::vaddvq_f32(sumv0)
-        }
-    }
-    fn vec_dot_q8_1_q8_1_neon_unrolled(abs: &[BlockQ8_1], bbs: &[BlockQ8_1]) -> f32 {
-        assert_eq!(abs.len(), bbs.len());
-        assert_eq!(
-            bbs.len() % 2,
-            0,
-            "bbs.len() must be a multiple of 64, got: {}",
-            bbs.len()
-        );
-
-        unsafe {
-            let mut sumv0 = aarch64::vdupq_n_f32(0.0);
-            let mut sumv1 = aarch64::vdupq_n_f32(0.0);
-            let zerov = aarch64::vdupq_n_s32(0);
-
-            for i in (0..bbs.len()).step_by(2) {
-                let ab0 = abs.get_unchecked(i);
-                let ab1 = abs.get_unchecked(i + 1);
-                let bb0 = bbs.get_unchecked(i);
-                let bb1 = bbs.get_unchecked(i + 1);
-
-                let av00 = aarch64::vld1q_s8(ab0.qs.as_ptr());
-                let av01 = aarch64::vld1q_s8(ab0.qs.as_ptr().add(16));
-                let av10 = aarch64::vld1q_s8(ab1.qs.as_ptr());
-                let av11 = aarch64::vld1q_s8(ab1.qs.as_ptr().add(16));
-
-                let bv00 = aarch64::vld1q_s8(bb0.qs.as_ptr());
-                let bv01 = aarch64::vld1q_s8(bb0.qs.as_ptr().add(16));
-                let bv10 = aarch64::vld1q_s8(bb1.qs.as_ptr());
-                let bv11 = aarch64::vld1q_s8(bb1.qs.as_ptr().add(16));
-
-                sumv0 = aarch64::vmlaq_n_f32(
-                    sumv0,
-                    aarch64::vcvtq_f32_s32(aarch64::vaddq_s32(
-                        aarch64::vdotq_s32(zerov, av00, bv00),
-                        aarch64::vdotq_s32(zerov, av01, bv01),
-                    )),
-                    ab0.d * bb0.d,
-                );
-
-                sumv1 = aarch64::vmlaq_n_f32(
-                    sumv1,
-                    aarch64::vcvtq_f32_s32(aarch64::vaddq_s32(
-                        aarch64::vdotq_s32(zerov, av10, bv10),
-                        aarch64::vdotq_s32(zerov, av11, bv11),
-                    )),
-                    ab1.d * bb1.d,
-                );
-            }
-
-            aarch64::vaddvq_f32(sumv0) + aarch64::vaddvq_f32(sumv1)
-        }
-    }
+    bs
 }
 
-#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-use impl_aarch64_neon::*;
-
-#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
-mod impl_x86_64_avx2 {
-    use std::arch::x86_64::*;
-
-    use super::BlockQ8_1;
-    pub fn quantize_f32_q8_1(data: &[f32]) -> Vec<BlockQ8_1> {
-        let mut bs = Vec::with_capacity(data.len() / 32);
-
-        unsafe {
-            for chunk in data.chunks(32) {
-                let mut max_abs_values = _mm256_setzero_ps();
-
-                for &value in chunk {
-                    let val_vec = _mm256_set1_ps(value);
-                    max_abs_values = _mm256_max_ps(
-                        max_abs_values,
-                        _mm256_andnot_ps(_mm256_set1_ps(-0.0), val_vec),
-                    );
-                }
-
-                let max_abs_value = {
-                    let mut max_vals = [0.0; 8];
-                    _mm256_storeu_ps(max_vals.as_mut_ptr(), max_abs_values);
-                    *max_vals
-                        .iter()
-                        .max_by(|x, y| x.partial_cmp(y).unwrap())
-                        .unwrap()
-                };
-
-                let d = max_abs_value / 127.0;
-                let d_vec = _mm256_set1_ps(d);
-                let mut qs = [0_i8; 32];
-                let mut temp = [0i32; 8]; // Temporary array to hold intermediate results
-                let mut s = 0f32; // Initialize s
-
-                for (chunk_index, values) in chunk.chunks(8).enumerate() {
-                    let values_vec = _mm256_loadu_ps(values.as_ptr());
-                    let scaled_vec = _mm256_div_ps(values_vec, d_vec);
-                    let clamped_vec = _mm256_max_ps(
-                        _mm256_set1_ps(i8::MIN as f32),
-                        _mm256_min_ps(_mm256_set1_ps(i8::MAX as f32), scaled_vec),
-                    );
-                    let converted_vec = _mm256_cvtps_epi32(clamped_vec);
-                    _mm256_storeu_si256(temp.as_mut_ptr() as *mut __m256i, converted_vec);
-
-                    for (i, &value) in temp.iter().enumerate() {
-                        qs[chunk_index * 8 + i] = value as i8;
-                        s += value as f32; // Accumulate the sum of scaled values
-                    }
-                }
-
-                s *= d; // Multiply the sum by d to get the final value of s
-
-                bs.push(BlockQ8_1 { d, s, qs });
-            }
+pub fn vec_dot_q8_1_q8_1(abs: &[BlockQ8_1], bbs: &[BlockQ8_1]) -> f32 {
+    let mut sumf: f32 = 0.0;
+    for i in 0..bbs.len() {
+        let mut sumi: i32 = 0;
+        let ad = f32::from(abs[i].d);
+        let bd = f32::from(bbs[i].d);
+        for j in 0..32 {
+            sumi += (abs[i].qs[j] as i32) * (bbs[i].qs[j] as i32);
         }
-
-        bs
+        sumf += sumi as f32 * ad * bd;
     }
-
-    pub fn vec_dot_q8_1_q8_1(abs: &[BlockQ8_1], bbs: &[BlockQ8_1]) -> f32 {
-        if bbs.len() % 2 == 0 {
-            return vec_dot_q8_1_q8_1_avx2_unrolled(abs, bbs);
-        }
-        vec_dot_q8_1_q8_1_avx2(abs, bbs)
-    }
-
-    fn vec_dot_q8_1_q8_1_avx2(abs: &[BlockQ8_1], bbs: &[BlockQ8_1]) -> f32 {
-        assert!(abs.len() == bbs.len());
-
-        unsafe {
-            let mut sum = 0f32;
-
-            for i in 0..bbs.len() {
-                let ab = &abs[i];
-                let bb = &bbs[i];
-
-                let av = _mm256_loadu_si256(ab.qs.as_ptr() as *const __m256i);
-                let bv = _mm256_loadu_si256(bb.qs.as_ptr() as *const __m256i);
-
-                let abs_diff = _mm256_sub_epi8(_mm256_max_epi8(av, bv), _mm256_min_epi8(av, bv));
-                let madd = _mm256_maddubs_epi16(abs_diff, _mm256_set1_epi8(1));
-                let sum_vec = _mm256_madd_epi16(madd, _mm256_set1_epi16(1));
-                let sum_low = _mm_extract_epi32(_mm256_extracti128_si256(sum_vec, 0), 0) as f32;
-                let sum_high = _mm_extract_epi32(_mm256_extracti128_si256(sum_vec, 1), 0) as f32;
-
-                sum += (sum_low + sum_high) * ab.d * bb.d;
-            }
-
-            sum
-        }
-    }
-
-    fn vec_dot_q8_1_q8_1_avx2_unrolled(abs: &[BlockQ8_1], bbs: &[BlockQ8_1]) -> f32 {
-        assert_eq!(abs.len(), bbs.len());
-        assert_eq!(
-            bbs.len() % 2,
-            0,
-            "bbs.len() must be a multiple of 64, got: {}",
-            bbs.len()
-        );
-
-        unsafe {
-            let mut sum = 0f32;
-
-            for i in (0..bbs.len()).step_by(2) {
-                let ab0 = &abs[i];
-                let ab1 = &abs[i + 1];
-                let bb0 = &bbs[i];
-                let bb1 = &bbs[i + 1];
-
-                let av0 = _mm256_loadu_si256(ab0.qs.as_ptr() as *const __m256i);
-                let av1 = _mm256_loadu_si256(ab1.qs.as_ptr() as *const __m256i);
-                let bv0 = _mm256_loadu_si256(bb0.qs.as_ptr() as *const __m256i);
-                let bv1 = _mm256_loadu_si256(bb1.qs.as_ptr() as *const __m256i);
-
-                let abs_diff0 =
-                    _mm256_sub_epi8(_mm256_max_epi8(av0, bv0), _mm256_min_epi8(av0, bv0));
-                let abs_diff1 =
-                    _mm256_sub_epi8(_mm256_max_epi8(av1, bv1), _mm256_min_epi8(av1, bv1));
-
-                let madd0 = _mm256_maddubs_epi16(abs_diff0, _mm256_set1_epi8(1));
-                let madd1 = _mm256_maddubs_epi16(abs_diff1, _mm256_set1_epi8(1));
-
-                let sum_vec0 = _mm256_madd_epi16(madd0, _mm256_set1_epi16(1));
-                let sum_vec1 = _mm256_madd_epi16(madd1, _mm256_set1_epi16(1));
-
-                let sum_low0 = _mm_extract_epi32(_mm256_extracti128_si256(sum_vec0, 0), 0) as f32;
-                let sum_high0 = _mm_extract_epi32(_mm256_extracti128_si256(sum_vec0, 1), 0) as f32;
-
-                let sum_low1 = _mm_extract_epi32(_mm256_extracti128_si256(sum_vec1, 0), 0) as f32;
-                let sum_high1 = _mm_extract_epi32(_mm256_extracti128_si256(sum_vec1, 1), 0) as f32;
-
-                sum += (sum_low0 + sum_high0) * ab0.d * bb0.d;
-                sum += (sum_low1 + sum_high1) * ab1.d * bb1.d;
-            }
-
-            sum
-        }
-    }
+    sumf
 }
-
-#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
-use impl_x86_64_avx2::*;
-
-#[cfg(not(any(
-    all(target_arch = "aarch64", target_feature = "neon"),
-    all(target_arch = "x86_64", target_feature = "avx2")
-)))]
-mod impl_fallback {
-    use super::BlockQ8_1;
-
-    pub fn quantize_f32_q8_1(data: &[f32]) -> Vec<BlockQ8_1> {
-        let mut bs = Vec::with_capacity(data.len() / 32);
-
-        for chunk in data.chunks(32) {
-            let mut max_abs_value = 0.0;
-
-            // Find the maximum absolute value in the chunk
-            for &value in chunk {
-                let abs_value = value.abs();
-                if abs_value > max_abs_value {
-                    max_abs_value = abs_value;
-                }
-            }
-
-            let d = max_abs_value / 127.0; // Compute the scaling factor
-            let mut qs = [0_i8; 32]; // Initialize the quantized values array
-            let mut s = 0f32; // Initialize the sum of scaled values
-
-            // Quantize the chunk
-            for (i, &value) in chunk.iter().enumerate() {
-                let scaled_value = value / d; // Scale the value
-                // Convert the scaled value to i8, clamping it to the i8 range
-                let quantized_value = scaled_value.max(i8::MIN as f32).min(i8::MAX as f32) as i8;
-                qs[i] = quantized_value;
-                s += quantized_value as f32; // Accumulate the sum of quantized values
-            }
-
-            s *= d; // Multiply the sum by d to get the final value of s
-
-            // Store the block with the scaling factor, quantized values, and the sum
-            bs.push(BlockQ8_1 { d, s, qs });
-        }
-
-        bs
-    }
-
-    pub fn vec_dot_q8_1_q8_1(abs: &[BlockQ8_1], bbs: &[BlockQ8_1]) -> f32 {
-        let mut sumf: f32 = 0.0;
-        for i in 0..bbs.len() {
-            let mut sumi: i32 = 0;
-            for j in 0..32 {
-                sumi += (abs[i].qs[j] as i32) * (bbs[i].qs[j] as i32);
-            }
-            sumf += sumi as f32 * abs[i].d * bbs[i].d;
-        }
-
-        sumf
-    }
-}
-
-#[cfg(not(any(
-    all(target_arch = "aarch64", target_feature = "neon"),
-    all(target_arch = "x86_64", target_feature = "avx2")
-)))]
-use impl_fallback::*;
 
 #[cfg(test)]
 mod tests {
@@ -470,8 +171,8 @@ mod tests {
         buf[79] = 7;
 
         let blocks = QuantBufQ8_1::from_bytes(&buf[0..40]).blocks;
-        assert_eq!(blocks[0].d, 3.0);
-        assert_eq!(blocks[0].s, 96.0);
+        assert_eq!(blocks[0].d.to_f32(), 3.0);
+        assert_eq!(blocks[0].s.to_f32(), 96.0);
         assert_eq!(blocks[0].qs, [
             2, 3, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 7

--- a/crabml-core/src/backends/cpu/buf/buf_q8_1.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_q8_1.rs
@@ -59,11 +59,8 @@ impl<'a> QuantBufQ8_1<'_> {
         })
     }
 
-    pub fn vec_dot(&self, a_offset: usize, b: &Self, b_offset: usize, len: usize) -> f32 {
-        let abs = &self.blocks[a_offset / 32..(a_offset + len) / 32];
-        let bbs = &b.blocks()[b_offset / 32..(b_offset + len) / 32];
-
-        vec_dot_q8_1_q8_1(abs, bbs)
+    pub fn vec_dot(&self, _a_offset: usize, _b: &Self, _b_offset: usize, _len: usize) -> f32 {
+        unreachable!("Q8_1 is not expected to have vec_dot computation")
     }
 }
 
@@ -122,20 +119,6 @@ pub fn quantize_f32_q8_1(data: &[f32]) -> Vec<BlockQ8_1> {
     }
 
     bs
-}
-
-pub fn vec_dot_q8_1_q8_1(abs: &[BlockQ8_1], bbs: &[BlockQ8_1]) -> f32 {
-    let mut sumf: f32 = 0.0;
-    for i in 0..bbs.len() {
-        let mut sumi: i32 = 0;
-        let ad = f32::from(abs[i].d);
-        let bd = f32::from(bbs[i].d);
-        for j in 0..32 {
-            sumi += (abs[i].qs[j] as i32) * (bbs[i].qs[j] as i32);
-        }
-        sumf += sumi as f32 * ad * bd;
-    }
-    sumf
 }
 
 #[cfg(test)]


### PR DESCRIPTION
it seems that q8_1 is only used on intermediate quantization while matmul with Q4_1, Q5_1 models. and the 8 bits quantization only existed on q8_0 and q8_0. 

so we do not need implement vec_dot for q8_1, and quantization is not performance critical, we can simplify it with plain rust code. (if SIMD is needed, we can just use stdsimd)