### PR TITLE
fix(tokenizer): utf8 error on decoding

### DIFF
--- a/crabml-core/src/tokenizer/bpe.rs
+++ b/crabml-core/src/tokenizer/bpe.rs
@@ -72,7 +72,7 @@ impl BpeTokenizer {
             }
         }
 
-        let mut s = String::from_utf8(piece.to_vec()).unwrap();
+        let mut s = String::from_utf8_lossy(piece).to_string();
         s = s.replace('▁', " ");
         Ok(s)
     }

--- a/crabml-core/src/tokenizer/bpe.rs
+++ b/crabml-core/src/tokenizer/bpe.rs
@@ -1,4 +1,3 @@
-use std::borrow::BorrowMut;
 use std::cell::RefCell;
 use std::collections::HashMap;
 


### PR DESCRIPTION
closes #134 

the reason why we got utf-8 error is that some tokens are not a valid utf-8 character, but it's part of a utf-8 sequence, we need buffer these bytes until it become a valid utf-8 character.

```
>> 如何避免过敏
 如果你想避免过敏，你可以尝试以下方法：

1. 检查药品的剂料和副作用：某些药品可能会对你产生过敏反应，因此你可以检查药品的剂料和副作用，以避免使用这些药品。
2. 减少药品的剂量：如果你发现药品对你产生过敏反应，你可以尝试减少药品的剂量，以减轻过敏反应。
3. 使用药品的替代品：如果你发现药品对你产生过敏反应，你可以尝试使用药品的替代品，以避免过敏反应。
4. 避免药品的剂料：如果你发现药品的剂料对你产生过敏反应，你可以避免使用这些药品。
5. 检查药品的剂量：如果你发现药品的剂量对你产生过敏反应，你可以检查药品的剂量，以避免使用过量的药品。
6. 检查药品的剂量：如果你发现药品的剂量对你产生过敏反应，你可以检查药品的剂量，以避免使用过量的药品。
7. 检查药品的剂量：如果你发现药品的剂量对你产生过敏反应，你可以检查药品的剂量，以避免使用过量的药品。

如果你仍然发现药品对你产生过敏反应，你可以咨询医生，以获得更多的帮助。
```