### PR TITLE
fix: make bpe invalid utf8 to �

### DIFF
--- a/crabml-core/src/tokenizer/bpe.rs
+++ b/crabml-core/src/tokenizer/bpe.rs
@@ -72,8 +72,11 @@ impl BpeTokenizer {
             }
         }
 
-        let mut s = String::from_utf8(piece.to_vec()).unwrap();
-        s = s.replace('▁', " ");
+        let result = String::from_utf8(piece.to_vec());
+        // if the token is not valid UTF-8, return a replacement character.
+        let s = result.unwrap_or_else(|_| "�".to_string());
+        let s = s.replace("▁", " ");
+
         Ok(s)
     }
 


### PR DESCRIPTION
## Summary

This PR addresses invalid UTF-8 encoding issues in tokens, preventing decode-related panics in Chinese contexts.

crabml:
```
./target/release/crabml-cli -m ~/Downloads/mistral-7b-instruct-v0.1.Q4_0.gguf  "克拉霉素干混悬剂用法用量?" --steps 100 -t 0.8 -p 1.0
loading model...
model loaded: 9ms
克拉霉素干混悬剂用法用量?

> 原文：<https://www.desmos.com/calculator/2qjw2j2j2j>

克拉thread 'main' panicked at crabml-core/src/tokenizer/bpe.rs:75:54:
called `Result::unwrap()` on an `Err` value: FromUtf8Error { bytes: [233], error: Utf8Error { valid_up_to: 0, error_len: None } }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR:
```
./target/release/crabml-cli -m ~/Downloads/mistral-7b-instruct-v0.1.Q4_0.gguf  "克拉霉素干混悬剂用法用量?" --steps 100 -t 0.8 -p 1.0
loading model...
model loaded: 3ms
克拉霉素干混悬剂用法用量?

> 原文：<https://www.desmos.com/calculator/2qjw2j2j2j>

克拉���素干混������用量取决于多种因素，包括药物的���度、药物的���量和���者的身体重量。在实际应用中，医生会根据��
prompt: 21 tokens, 2753ms
8.011102025520026 tokens/s, 2 threads
```

Adding a unit test for just the `decode` function is challenging because the function expects a `Vec<String>` for the `tokens` parameter, and we cannot create an invalid UTF-8 string. Therefore, this pull request does not include any tests.