### PR TITLE
chore(tensor): remove div_scalar_inplace

### DIFF
--- a/crabml-core/src/cpu/cpu_tensor.rs
+++ b/crabml-core/src/cpu/cpu_tensor.rs
@@ -411,14 +411,6 @@ impl<'a> Tensor for CpuTensor<'a> {
         Ok(self)
     }
 
-    fn div_scalar_inplace(mut self, b: f32) -> Result<Self> {
-        let rhs = CpuTensor::new(vec![b], &[1], self.device())?;
-        let strider1 = self.strider().clone();
-        let strider2 = rhs.strider();
-        primitives::div_inplace(self.buf_mut(), rhs.buf(), &strider1, strider2)?;
-        Ok(self)
-    }
-
     fn scale_inplace(mut self, rhs: f32) -> Result<Self> {
         let rhs = CpuTensor::new(vec![rhs], &[1], self.device())?;
         let strider1 = self.strider().clone();

--- a/crabml-core/src/tensor/api.rs
+++ b/crabml-core/src/tensor/api.rs
@@ -66,9 +66,10 @@ pub trait Tensor: Sized + Clone {
 
     fn mul_inplace(self, rhs: &Self) -> Result<Self>;
 
+    /// there're two cases:
+    /// 1. both self and rhs have the same shape, it's an element-wise operation.
+    /// 2. self are 2d tensor, rhs is 1d tensor, it's a broadcast element-wise operation.
     fn add_inplace(self, rhs: &Self) -> Result<Self>;
-
-    fn div_scalar_inplace(self, rhs: f32) -> Result<Self>;
 
     fn scale_inplace(self, rhs: f32) -> Result<Self>;
 

--- a/crabml-llama2/src/llama2.rs
+++ b/crabml-llama2/src/llama2.rs
@@ -450,7 +450,7 @@ impl<'a, T: Tensor> Llama2Runner<T> {
                 .reshape(&[n_batch, n_heads, head_dim])?
                 .transpose(&[1, 0, 2])?
                 .contiguous()?
-                .div_scalar_inplace((head_dim as f32).sqrt())?;
+                .scale_inplace(1.0 / (head_dim as f32).sqrt())?;
 
             // get attention scores:
             // - key_cache: [n_kv_head, seq, head_size].transpose(0, 2, 1) => [n_kv_head, head_size, seq]

--- a/crabml-vulkan/src/vulkan_tensor.rs
+++ b/crabml-vulkan/src/vulkan_tensor.rs
@@ -153,6 +153,7 @@ impl Tensor for VulkanTensor {
     fn mul_inplace(self, rhs: &Self) -> Result<Self> {
         assert!(self.strider.is_contiguous());
         assert!(rhs.strider.is_contiguous());
+        assert!(self.strider.len() % rhs.strider.len() == 0);
 
         let n_elms = self.strider.len() as u32;
         let bufs = vec![self.buf.clone(), rhs.buf.clone()];
@@ -172,6 +173,7 @@ impl Tensor for VulkanTensor {
     fn add_inplace(self, rhs: &Self) -> Result<Self> {
         assert!(self.strider.is_contiguous());
         assert!(rhs.strider.is_contiguous());
+        assert!(self.strider.len() % rhs.strider.len() == 0);
 
         let n_elms = self.strider.len() as u32;
         let bufs = vec![self.buf.clone(), rhs.buf.clone()];
@@ -180,24 +182,6 @@ impl Tensor for VulkanTensor {
             op: '+' as u32,
             use_scalar_rhs: 0,
             scalar_rhs: 0.0,
-        };
-        let dispatches = [n_elms / 32 + 1, 1, 1];
-        self.device
-            .inner
-            .dispatch_compute("arithmetic", bufs, pcs, dispatches);
-        Ok(self)
-    }
-
-    fn div_scalar_inplace(self, rhs: f32) -> Result<Self> {
-        assert!(self.strider.is_contiguous());
-
-        let n_elms = self.strider.len() as u32;
-        let bufs = vec![self.buf.clone(), self.buf.clone()];
-        let pcs = ArithmeticPushConstants {
-            n_elms,
-            op: '/' as u32,
-            use_scalar_rhs: 1,
-            scalar_rhs: rhs,
         };
         let dispatches = [n_elms / 32 + 1, 1, 1];
         self.device
@@ -281,25 +265,6 @@ mod tests {
             0.0, 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 22.0, 24.0, 26.0, 28.0,
             30.0, 32.0, 34.0, 36.0, 38.0, 40.0, 42.0, 44.0, 46.0, 48.0, 50.0, 52.0, 54.0, 56.0,
             58.0, 60.0, 62.0, 64.0, 66.0
-        ]);
-        Ok(())
-    }
-
-    #[test]
-    fn test_div_scalar() -> Result<()> {
-        let d = VulkanTensorDevice::new(VulkanTensorDeviceOptions::default());
-
-        let buf1 = (0..32).map(|v| v as f32).collect::<Vec<_>>();
-
-        let t1 = VulkanTensor::new(&buf1, &[32], d.clone()).unwrap();
-
-        let t1 = t1.div_scalar_inplace(2.0).unwrap();
-        let mut bufo = vec![0.0; 32];
-        t1.export(&mut bufo)?;
-
-        assert_eq!(bufo, vec![
-            0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0,
-            8.5, 9.0, 9.5, 10.0, 10.5, 11.0, 11.5, 12.0, 12.5, 13.0, 13.5, 14.0, 14.5, 15.0, 15.5
         ]);
         Ok(())
     }


### PR DESCRIPTION
div_scalar_inplace can be replaced with `scale_inplace` which might have a better numerial stability