### PR TITLE
fix: using fixed version ubuntu 22.04 in github workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Format
@@ -21,7 +21,7 @@ jobs:
       run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
since ubuntu-latest has been update to ubuntu-24.04 (Noble) which break current vulkan installation with jammy (ubuntu-22.04)