### PR TITLE
fix: enable bytemuck feature for half in crabml-{core,llama2}/Cargo.toml

### DIFF
--- a/crabml-core/Cargo.toml
+++ b/crabml-core/Cargo.toml
@@ -9,12 +9,11 @@ description = "crabml core package"
 [dependencies]
 int-enum = "0.5.0"
 memmap2 = "0.7.1"
-half = { version = "2.3.1" }
+half = { version = "2.3.1", features = ["bytemuck"]}
 bytemuck = { version = "1.14.0", features = ["derive"] }
 byteorder = "1.5.0"
 crossbeam-channel = "0.5"
 regex = "1"
-vulkano = "0.34.1"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/crabml-llama2/Cargo.toml
+++ b/crabml-llama2/Cargo.toml
@@ -10,7 +10,7 @@ description = "crabml llama2 support"
 rand = "0.8.5"
 crabml = { workspace = true }
 crabml-vulkan = { workspace = true }
-half = { version = "2.3.1" }
+half = { version = "2.3.1", features = ["bytemuck"]}
 
 [dev-dependencies]
 approx = "0.5.1"


### PR DESCRIPTION
fix `cargo test -p crabml` requires vulkano as dependency, and improve `crabml-core` build/test performance a little bit.